### PR TITLE
chore: fix sync example path + annotate legacy importer heuristics

### DIFF
--- a/crates/cli/src/commands/sync.rs
+++ b/crates/cli/src/commands/sync.rs
@@ -50,7 +50,7 @@ struct SyncManifest {
 struct ProjectSync {
     /// Vercel project ID
     project_id: String,
-    /// Vault path prefix for this project's secrets (e.g., "revealui/vercel/cms")
+    /// Vault path prefix for this project's secrets (e.g., "revealui/vercel/admin")
     vault_prefix: String,
     /// Environment targets: production, preview, development
     #[serde(default = "default_targets")]

--- a/crates/core/src/import/plaintext.rs
+++ b/crates/core/src/import/plaintext.rs
@@ -141,11 +141,18 @@ fn categorize_by_filename(name: &str) -> (&str, String, &str) {
     if lower.contains("redis") {
         return ("credentials/redis", sanitize_name(name), "filename:redis");
     }
+    // NOTE: Resend was removed from the RevealUI stack on 2026-04-09 in favor of
+    // Gmail API via Google Workspace. Kept here as a legacy-migration heuristic
+    // so users importing older plaintext dumps still get sensible categorization.
     if lower.contains("resend") {
         return ("credentials/resend", sanitize_name(name), "filename:resend");
     }
 
-    // AI providers
+    // AI providers. NOTE: BYOK (bring-your-own-key) for customer-facing proprietary
+    // providers was removed 2026-04-05 — the RevealUI AI stack is open-model-only.
+    // These heuristics remain for plaintext imports of older dev-machine dumps
+    // where Joshua personally holds OpenAI/Anthropic keys; they are no longer a
+    // supported customer path.
     if lower.contains("openai") || lower.contains("gpt") {
         return ("credentials/openai", sanitize_name(name), "filename:openai");
     }


### PR DESCRIPTION
## Summary

Two small drift fixes surfaced in the 2026-04-23 suite-wide messaging audit:

1. **CLI sync example pointed to the wrong Vercel project.** `ProjectSync::vault_prefix` doc example showed `revealui/vercel/cms`; the `cms` app renamed to `admin` on 2026-04-09 (revealui PR #227). Anyone copy-pasting this into a real sync manifest would target the wrong project. Swapped to `revealui/vercel/admin`.
2. **Plaintext importer heuristics annotated as legacy.** The importer still matches `resend` / `openai` / `anthropic` filename patterns for auto-categorization, which is correct behavior for importing older plaintext dumps — but a reader glancing at the code would reasonably infer those services are still part of the current stack. Added inline comments noting Resend was removed 2026-04-09 (Gmail-only) and BYOK proprietary-provider paths were removed 2026-04-05 (open-model-only). **Behavior unchanged — comments only.**

(A third audit item — `.claude/CLAUDE.md` build command pointing to `~/projects/revault` — turned out to be a local untracked file, not in git, so nothing to ship here.)

**Source:** internal docs § revvault`.

## Test plan
- [ ] `cargo build --workspace` green
- [ ] `cargo test --workspace` green (behavior of `plaintext::categorize` is byte-identical — comments only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
