### PR TITLE
chore(ci): tier 5 + 7 hardening — cargo doc (required) + pnpm audit (advisory)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,3 +218,44 @@ jobs:
         run: cargo install cargo-deny --locked
       - name: cargo deny check
         run: cargo deny check
+
+  doc:
+    # cargo-doc with -D warnings catches broken intra-doc links and
+    # missing doc items. Treats doc rot as a build error.
+    name: cargo doc -D warnings
+    runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: -D warnings
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: cargo doc -p revvault-core -p revvault-cli --no-deps
+        run: cargo doc -p revvault-core -p revvault-cli --no-deps
+
+  pnpm-audit:
+    # pnpm audit on the frontend deps. Equivalent of cargo-audit for the
+    # Node.js side. ADVISORY for now (continue-on-error: true) because
+    # the initial run on revvault frontend surfaced 4 existing
+    # vulnerabilities (2 moderate vite/picomatch, 2 high). Tracked
+    # separately for triage. Flip continue-on-error → false once
+    # those are addressed.
+    name: pnpm audit (frontend)
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+      - name: pnpm install (frozen lockfile)
+        run: pnpm install --frozen-lockfile --ignore-scripts
+        working-directory: frontend
+      - name: pnpm audit --audit-level=high
+        run: pnpm audit --audit-level=high
+        working-directory: frontend

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -36,7 +36,7 @@ enum Commands {
     Completions(commands::completions::CompletionsArgs),
     /// Migrate secrets from external sources
     Migrate(commands::migrate::MigrateArgs),
-    /// [PLANNED] Rotate API keys for a provider
+    /// `[PLANNED]` Rotate API keys for a provider
     Rotate(commands::rotate::RotateArgs),
     /// Show rotation status
     RotationStatus,


### PR DESCRIPTION
## Summary

Tier 5 + 7 of the revvault CI hardening sweep. Tier 6 (Tauri-app CI workflow) is deferred to a separate PR — it needs its own multi-platform workflow with `libwebkit2gtk-4.1-dev` on the Linux runner + native macOS/Windows Tauri toolchains.

| Job | Purpose | Status |
|---|---|---|
| **cargo doc -D warnings** | Catches broken intra-doc links + missing module docs | **Required** |
| **pnpm audit (frontend)** | Node.js advisory database scan, equivalent of cargo-audit for the frontend | **Advisory** (continue-on-error: true) for now |

## Tier 5 — cargo doc

Single new job under `RUSTDOCFLAGS="-D warnings"`. Local verification surfaced one existing broken-doc-link in [`crates/cli/src/main.rs:39`](crates/cli/src/main.rs#L39): the `[PLANNED]` text in a doc comment was being interpreted as an intra-doc link. Fixed in this PR by wrapping in backticks (`` `[PLANNED]` ``).

After this PR, `cargo doc` will block PRs on doc rot.

## Tier 7 — pnpm audit (advisory)

Initial scan on revvault frontend surfaced **4 existing vulnerabilities**:

| Severity | Count | Notable |
|---|---|---|
| high | 2 | (one is in transitive dep tree of vite) |
| moderate | 2 | vite path-traversal in optimized-deps `.map` handling (`<=6.4.1`, fix `>=6.4.2`); picomatch ReDoS (`GHSA-3v7f-55p6-f55p`) |

These are existing, not introduced by this PR. Marking the new gate `continue-on-error: true` so it doesn't block PRs while we triage. **Plan**:
- Open a follow-up PR to bump vite to ≥ 6.4.2 + run `pnpm update --latest` for picomatch
- Re-run `pnpm audit --audit-level=high`; once clean, flip `continue-on-error: false` + add to required branch protection

## Verification (local)

```
RUSTDOCFLAGS="-D warnings" cargo doc -p revvault-core -p revvault-cli --no-deps   exit 0
pnpm audit                                                                        surfaced 4 vulns (expected)
cargo build / test / clippy / fmt                                                 no regressions
```

## Test plan

- [ ] CI green on this PR (cargo doc as new required; pnpm audit as advisory should fail-tolerate)
- [ ] After merge: branch protection rule on `main` adds `cargo doc -D warnings` to required (separate `gh api` PUT)
- [ ] Follow-up: triage frontend vite + picomatch vulnerabilities; flip `pnpm audit (frontend)` to required

## Tier 6 follow-up

Tauri-app CI workflow tracked separately; needs:
- Linux runner: `apt-get install libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev`
- macOS / Windows runners: native Tauri toolchains
- Multi-platform matrix (each platform has different blast radius)
- Likely 5-10 min CI time per leg
