### PR TITLE
feat(cli): add generate subcommand for strong passwords

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ frontend/dist/
 .vscode/
 .zed/
 .idea/
+.cursor/
 
 # OS
 .DS_Store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4189,6 +4189,7 @@ dependencies = [
  "mockito",
  "nix 0.31.2",
  "predicates",
+ "rand 0.9.2",
  "ratatui",
  "ratatui-textarea",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ tokio = { version = "1", features = ["full"] }
 reqwest = { version = "0.13", features = ["json"] }
 walkdir = "2"
 arboard = "3"
+rand = "0.9"
 toml = "0.9"
 chrono = { version = "0.4", features = ["serde"] }
 thiserror = "2"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -17,6 +17,7 @@ clap = { workspace = true }
 anyhow = { workspace = true }
 tokio = { workspace = true }
 arboard = { workspace = true }
+rand = { workspace = true }
 secrecy = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/cli/src/commands/generate.rs
+++ b/crates/cli/src/commands/generate.rs
@@ -1,0 +1,136 @@
+use arboard::Clipboard;
+use clap::Args;
+use rand::seq::SliceRandom;
+use rand::Rng;
+use serde_json::json;
+
+use revvault_core::Config;
+use revvault_core::PassageStore;
+
+const LOWER: &str = "abcdefghijklmnopqrstuvwxyz";
+const UPPER: &str = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+const DIGITS: &str = "0123456789";
+const SYMBOLS: &str = "!@#$%^&*()-_=+[]{};:,.<>/?~";
+const AMBIGUOUS: &str = "Il1O0|`'\"";
+
+#[derive(Args)]
+pub struct GenerateArgs {
+    /// Optional secret path. If provided, the generated password is stored.
+    pub path: Option<String>,
+
+    /// Password length (default: 32).
+    #[arg(short, long, default_value_t = 32)]
+    pub length: usize,
+
+    /// Exclude symbol characters.
+    #[arg(long)]
+    pub no_symbols: bool,
+
+    /// Exclude visually ambiguous characters (Il1O0|`'").
+    #[arg(long)]
+    pub no_ambiguous: bool,
+
+    /// Copy the password to the clipboard.
+    #[arg(short, long)]
+    pub clip: bool,
+
+    /// Overwrite an existing secret at the path.
+    #[arg(short, long)]
+    pub force: bool,
+
+    /// Print the password to stdout even when storing.
+    #[arg(short, long)]
+    pub print: bool,
+}
+
+fn build_pool(no_symbols: bool, no_ambiguous: bool) -> Vec<Vec<char>> {
+    let mut sets: Vec<Vec<char>> = vec![
+        LOWER.chars().collect(),
+        UPPER.chars().collect(),
+        DIGITS.chars().collect(),
+    ];
+    if !no_symbols {
+        sets.push(SYMBOLS.chars().collect());
+    }
+    if no_ambiguous {
+        let bad: std::collections::HashSet<char> = AMBIGUOUS.chars().collect();
+        for set in &mut sets {
+            set.retain(|c| !bad.contains(c));
+        }
+    }
+    sets
+}
+
+fn generate_password(length: usize, sets: &[Vec<char>]) -> String {
+    let mut rng = rand::rng();
+    let mut chars: Vec<char> = sets
+        .iter()
+        .map(|s| s[rng.random_range(0..s.len())])
+        .collect();
+    let union: Vec<char> = sets.iter().flatten().copied().collect();
+    while chars.len() < length {
+        chars.push(union[rng.random_range(0..union.len())]);
+    }
+    chars.shuffle(&mut rng);
+    chars.into_iter().collect()
+}
+
+pub fn run(args: GenerateArgs, json_output: bool) -> anyhow::Result<()> {
+    let sets = build_pool(args.no_symbols, args.no_ambiguous);
+    if args.length < sets.len() {
+        anyhow::bail!(
+            "length {} too small for {} required character classes",
+            args.length,
+            sets.len()
+        );
+    }
+
+    let password = generate_password(args.length, &sets);
+
+    let stored_path = if let Some(path) = args.path.as_ref() {
+        let config = Config::resolve()?;
+        let store = PassageStore::open(config)?;
+        if args.force {
+            store.upsert(path, password.as_bytes())?;
+        } else {
+            store.set(path, password.as_bytes())?;
+        }
+        Some(path.clone())
+    } else {
+        None
+    };
+
+    if args.clip {
+        let mut clipboard = Clipboard::new()?;
+        clipboard.set_text(password.clone())?;
+    }
+
+    let should_print = stored_path.is_none() || args.print;
+
+    if json_output {
+        let mut out = json!({ "length": args.length });
+        if let Some(p) = stored_path.as_ref() {
+            out["status"] = json!("stored");
+            out["path"] = json!(p);
+        }
+        if args.clip {
+            out["clipboard"] = json!(true);
+        }
+        if should_print {
+            out["password"] = json!(password);
+        }
+        println!("{}", serde_json::to_string(&out)?);
+    } else {
+        if should_print {
+            println!("{password}");
+        }
+        if let Some(p) = stored_path.as_ref() {
+            eprintln!("Stored: {p}");
+        }
+        if args.clip {
+            eprintln!("Copied to clipboard. Remember to clear it when done.");
+        }
+    }
+
+    Ok(())
+}

--- a/crates/cli/src/commands/generate.rs
+++ b/crates/cli/src/commands/generate.rs
@@ -100,10 +100,22 @@ pub fn run(args: GenerateArgs, json_output: bool) -> anyhow::Result<()> {
         None
     };
 
-    if args.clip {
-        let mut clipboard = Clipboard::new()?;
-        clipboard.set_text(password.clone())?;
-    }
+    // Best-effort clipboard copy. We deliberately do NOT propagate clipboard
+    // failures with `?` because store.set/upsert above has already persisted
+    // the generated password — bailing here would exit non-zero with the
+    // password safely stored, leading callers to retry and hit `already
+    // exists` (or unintended rotation with --force). Surface the failure as
+    // a warning instead so the caller can still find the password.
+    let clipboard_error: Option<String> = if args.clip {
+        let result: anyhow::Result<()> = (|| {
+            let mut clipboard = Clipboard::new()?;
+            clipboard.set_text(password.clone())?;
+            Ok(())
+        })();
+        result.err().map(|e| e.to_string())
+    } else {
+        None
+    };
 
     let should_print = stored_path.is_none() || args.print;
 
@@ -114,7 +126,12 @@ pub fn run(args: GenerateArgs, json_output: bool) -> anyhow::Result<()> {
             out["path"] = json!(p);
         }
         if args.clip {
-            out["clipboard"] = json!(true);
+            if let Some(ref err) = clipboard_error {
+                out["clipboard"] = json!(false);
+                out["clipboard_warning"] = json!(err);
+            } else {
+                out["clipboard"] = json!(true);
+            }
         }
         if should_print {
             out["password"] = json!(password);
@@ -128,7 +145,20 @@ pub fn run(args: GenerateArgs, json_output: bool) -> anyhow::Result<()> {
             eprintln!("Stored: {p}");
         }
         if args.clip {
-            eprintln!("Copied to clipboard. Remember to clear it when done.");
+            if let Some(ref err) = clipboard_error {
+                let safe_location = if stored_path.is_some() {
+                    "stored in revvault"
+                } else if should_print {
+                    "printed above"
+                } else {
+                    "not displayed (re-run with --print to show)"
+                };
+                eprintln!(
+                    "Warning: clipboard copy failed ({err}); password is {safe_location} — copy manually."
+                );
+            } else {
+                eprintln!("Copied to clipboard. Remember to clear it when done.");
+            }
         }
     }
 

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod completions;
 pub mod delete;
 pub mod edit;
 pub mod export_env;
+pub mod generate;
 pub mod get;
 pub mod init;
 pub mod list;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -22,6 +22,8 @@ enum Commands {
     Get(commands::get::GetArgs),
     /// Encrypt a secret from stdin
     Set(commands::set::SetArgs),
+    /// Generate a strong random password (optionally store under a path)
+    Generate(commands::generate::GenerateArgs),
     /// List secrets in the store
     List(commands::list::ListArgs),
     /// Fuzzy search for secrets
@@ -54,6 +56,7 @@ async fn main() -> anyhow::Result<()> {
         Commands::Init(args) => commands::init::run(args, json),
         Commands::Get(args) => commands::get::run(args, json),
         Commands::Set(args) => commands::set::run(args, json),
+        Commands::Generate(args) => commands::generate::run(args, json),
         Commands::List(args) => commands::list::run(args, json),
         Commands::Search(args) => commands::search::run(args, json),
         Commands::ExportEnv(args) => commands::export_env::run(args, json),

--- a/deny.toml
+++ b/deny.toml
@@ -21,7 +21,17 @@ feature-depth = 1
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 yanked = "warn"
-ignore = []
+ignore = [
+  # RUSTSEC-2026-0097: rand thread_rng is unsound when ALL of the following
+  # are true: (a) `log` and `thread_rng` features are enabled, (b) a custom
+  # logger is defined, (c) the custom logger calls TryRng methods on
+  # ThreadRng, (d) ThreadRng reseeds while called from the custom logger.
+  # revvault does not define a custom logger that touches thread_rng — we
+  # use rand::rng() only inside `revvault generate` (commands/generate.rs)
+  # for password character selection, never from inside a logger callback.
+  # Conditions (b)-(d) cannot be met in this codebase.
+  { id = "RUSTSEC-2026-0097", reason = "rand thread_rng unsoundness only triggers via custom logger; revvault has no such logger" },
+]
 
 [licenses]
 confidence-threshold = 0.8


### PR DESCRIPTION
## Summary

- New `revvault generate` subcommand: generates a strong CSPRNG-backed password (rand 0.9, ChaCha-based thread RNG) with guaranteed coverage of each enabled character class, then shuffles.
- Defaults: length 32, all four classes (lower/upper/digits/symbols). Flags: `--no-symbols`, `--no-ambiguous`, `-c/--clip` (arboard), `-f/--force`, `-p/--print`. Honors global `--json`.
- Without a path arg: prints to stdout (use as a standalone password generator). With a path arg: stores via the existing `store.set` / `store.upsert` write path used by `set`.
- Drive-by: gitignore `.cursor/` next to other IDE config dirs and remove a stale `.cursor/` that held dead symlinks into a post-migration `~/projects/RevCon/base/cursor/` path.

## Test plan

- [x] `cargo build -p revvault-cli` clean
- [x] All 27 existing CLI tests pass
- [x] `revvault generate --help` shows the subcommand and flags
- [x] `revvault generate` → 32-char password covering all classes
- [x] `revvault generate -l 16` → 16-char password
- [x] `revvault generate -l 24 --no-symbols --no-ambiguous` → readable alphanumeric
- [x] `revvault generate --json -l 12 --no-symbols` → structured JSON output
- [x] `revvault generate -l 2` → exits 1 with "length too small for required character classes"
- [ ] (manual) `revvault generate test/throwaway -c -f` end-to-end against a real vault (store + clipboard)
