### PR TITLE
chore(ci): SHA-pin all 37 actions in revvault ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,9 @@ jobs:
     name: Test (core + cli)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       # The Tauri desktop crate (`revvault-tauri`) is excluded because it
       # requires libwebkit2gtk-4.1-dev + libgtk-3-dev and ships through a
       # separate release pipeline.
@@ -38,8 +38,8 @@ jobs:
     name: cargo fmt --check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: rustfmt
       - name: cargo fmt --check --all
@@ -49,11 +49,11 @@ jobs:
     name: cargo clippy -D warnings
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       # Workspace clippy would pull in revvault-tauri whose deps need gtk;
       # mirror the test job's scope and lint core + cli only. Matches the
       # standard set in scripts/ci.sh + .claude/rules/rust.md ("Run cargo
@@ -65,11 +65,11 @@ jobs:
     name: pnpm build (tsc + vite)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
         with:
           version: 10
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 20
           cache: pnpm
@@ -85,11 +85,11 @@ jobs:
     name: pnpm test (vitest)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
         with:
           version: 10
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 20
           cache: pnpm
@@ -106,8 +106,8 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v6
-      - uses: ludeeus/action-shellcheck@2.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
         with:
           severity: warning
 
@@ -115,7 +115,7 @@ jobs:
     name: anti-regression — no hardcoded "joshu"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Grep for hardcoded "joshu" in scripted files
         run: |
           set -euo pipefail
@@ -144,10 +144,10 @@ jobs:
     name: Gitleaks (full history)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v2
+      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -166,9 +166,9 @@ jobs:
         os: [macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: cargo test -p revvault-core -p revvault-cli --all-targets
         run: cargo test -p revvault-core -p revvault-cli --all-targets
 
@@ -183,9 +183,9 @@ jobs:
     name: MSRV (rust 1.88)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@1.88
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: dtolnay/rust-toolchain@98e1b82157cd469e843cb7f524c1313b4ad9492c # 1.88
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: cargo build -p revvault-core -p revvault-cli
         run: cargo build -p revvault-core -p revvault-cli
 
@@ -196,9 +196,9 @@ jobs:
     name: cargo audit (RustSec)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Install cargo-audit
         run: cargo install cargo-audit --locked
       - name: cargo audit
@@ -211,9 +211,9 @@ jobs:
     name: cargo deny
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Install cargo-deny
         run: cargo install cargo-deny --locked
       - name: cargo deny check
@@ -227,9 +227,9 @@ jobs:
     env:
       RUSTDOCFLAGS: -D warnings
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: cargo doc -p revvault-core -p revvault-cli --no-deps
         run: cargo doc -p revvault-core -p revvault-cli --no-deps
 
@@ -244,11 +244,11 @@ jobs:
     name: pnpm audit (frontend)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
         with:
           version: 10
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 20
           cache: pnpm


### PR DESCRIPTION
## Summary

revvault's `ci.yml` is the entire workflow surface (single file). All 37 `uses:` references used floating tags. This PR pins each one to a specific commit SHA resolved via the GitHub API.

## Changes

| Action | Before | After | Count |
|---|---|---|---|
| `actions/checkout` | `@v6` | `@de0fac2e... # v6` | 14 |
| `dtolnay/rust-toolchain` | `@stable` | `@29eef336... # stable` | 9 |
| `Swatinem/rust-cache` | `@v2` | `@e18b4977... # v2` | 7 |
| `actions/setup-node` | `@v6` | `@48b55a01... # v6` | 3 |
| `pnpm/action-setup` | `@v6` | `@903f9c1a... # v6.0.3` | 3 |
| `dtolnay/rust-toolchain` | `@1.88` | `@98e1b821... # 1.88` | 1 |
| `ludeeus/action-shellcheck` | `@2.0.0` | `@00cae500... # 2.0.0` | 1 |
| `gitleaks/gitleaks-action` | `@v2` | `@ff98106e... # v2` | 1 |

**Total: 37 line replacements in `.github/workflows/ci.yml`** (37 ins / 37 del; no functional change).

## Why

GitHub Actions tag references (`@v6`, `@stable`, etc.) are mutable: an action repo owner — or an attacker who compromises one — can move the tag to a malicious commit. SHA pinning makes the reference content-addressed; a malicious update would have to ship a new SHA, which Dependabot then proposes as an explicit, reviewable PR rather than a silent re-target. Reference: [`tj-actions/changed-files` 2025-03 incident](https://github.com/tj-actions/changed-files/issues/2464).

This PR is the cross-suite extension of [revealui#718](https://github.com/RevealUIStudio/revealui/pull/718) (sister PR which pinned 7 unpinned references in 2 revealui workflows).

## SHA resolution

Each SHA was resolved via `gh api repos/{owner}/{repo}/commits/{ref}` which dereferences the ref (whether tag, branch, or sha-alias) to the underlying commit. The resolved SHAs match what `git ls-remote refs/tags/{tag}^{}` returns. No hand-typed SHAs.

## Notes on `dtolnay/rust-toolchain@stable`

The `stable` ref in `dtolnay/rust-toolchain` is a branch that the maintainer force-pushes when Rust stable advances. By pinning to a specific SHA, this workflow no longer auto-tracks Rust stable releases — Dependabot will propose explicit bumps as new SHAs ship at `stable`. This is the correct security posture (explicit > silent), but the workflow's effective Rust version will not advance until Dependabot's update PRs are merged. If the project wants automatic Rust stable tracking, leave this single ref unpinned (revert just that line).

## Test plan

- [x] Audit script confirmed zero remaining unpinned `uses:` after edits (`grep -nE "^\s+(- )?uses: [^@]+@[^a-f0-9]" .github/workflows/ci.yml` returns nothing)
- [x] Each new SHA resolved live via `gh api repos/{owner}/{repo}/commits/{ref}` (not hand-typed)
- [x] `git diff --stat` shows clean 37 ins / 37 del replacement (no whitespace drift)
- [ ] CI green on this PR (test core+cli, fmt, clippy, frontend-build, all hardening tiers, gitleaks, shellcheck)

## Follow-up (separate sweep)

Other suite repos (agency, revcon, revskills, etc.) may also have unpinned actions. Track in a future sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
