### PR TITLE
feat(rotation): post-rotate hooks + strict verify + local generator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4214,7 +4214,9 @@ dependencies = [
  "chrono",
  "dirs",
  "fuzzy-matcher",
+ "hex",
  "mockito",
+ "rand 0.9.2",
  "reqwest",
  "secrecy",
  "serde",
@@ -4223,6 +4225,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "toml 0.9.12+spec-1.1.0",
+ "uuid",
  "walkdir",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ reqwest = { version = "0.13", features = ["json"] }
 walkdir = "2"
 arboard = "3"
 rand = "0.9"
+hex = "0.4"
+uuid = { version = "1", features = ["v4"] }
 toml = "0.9"
 chrono = { version = "0.4", features = ["serde"] }
 thiserror = "2"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -22,6 +22,9 @@ chrono = { workspace = true }
 toml = { workspace = true }
 reqwest = { workspace = true }
 tokio = { workspace = true }
+rand = { workspace = true }
+hex = { workspace = true }
+uuid = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/core/src/rotation/config.rs
+++ b/crates/core/src/rotation/config.rs
@@ -28,6 +28,21 @@ pub struct ProviderConfig {
     /// failure semantics.
     #[serde(default)]
     pub sync: Option<SyncConfig>,
+    /// User-configurable shell commands to run after the vault
+    /// write + sync hook complete. Executed sequentially with
+    /// `sh -c`. Failure is **warn-only** — the rotation is not
+    /// aborted because the new key is already live in the vault.
+    /// Use `verify` for a strict gate.
+    #[serde(default)]
+    pub post_rotate: Vec<String>,
+    /// Optional strict verification command. When set, runs after
+    /// the `post_rotate` hooks. Exit-zero records `verified: true`
+    /// in the rotation log; **non-zero records `verified: false`
+    /// AND causes the executor to return Err** (cli exits non-zero).
+    /// Vault state is unchanged either way — the rotation already
+    /// landed.
+    #[serde(default)]
+    pub verify: Option<String>,
 }
 
 impl RotationConfig {

--- a/crates/core/src/rotation/executor.rs
+++ b/crates/core/src/rotation/executor.rs
@@ -2,14 +2,25 @@
 //!
 //! The executor is the glue between the vault and rotation providers.
 //! It reads the current key from the vault, builds the provider, runs
-//! the rotation, writes the new key back, and appends a log entry.
+//! the rotation, writes the new key back, runs the sync hook, the
+//! `post_rotate` user hooks, the `verify` gate, and finally appends a
+//! log entry.
+//!
+//! # Failure semantics
+//!
+//! - The `apply_sync_after_rotation` step is infallible at the function
+//!   level — sync target failures land as log rows + stderr warnings.
+//! - `post_rotate` hooks are warn-on-failure — a failing hook does not
+//!   abort the rotation (the new key is already in the vault).
+//! - The `verify` step is **strict** — a failing verify writes a log
+//!   entry with `verified: false` and then the executor returns Err so
+//!   the cli exits non-zero. Vault state is unchanged.
 
 use std::io::Write as _;
 
 use chrono::Utc;
 use secrecy::{ExposeSecret as _, SecretString};
 
-use crate::error::Result;
 use crate::rotation::config::ProviderConfig;
 use crate::rotation::provider::RotationLogEntry;
 use crate::rotation::providers::build_provider;
@@ -27,34 +38,43 @@ fn key_id_path(secret_path: &str) -> String {
 /// Steps:
 /// 1. Read current key from vault
 /// 2. Read previous key ID from vault (if stored)
-/// 3. Build and preflight the provider
+/// 3. Build and preflight the provider (factory in `providers::build_provider`)
 /// 4. Execute rotation (create new key, revoke old key)
 /// 5. Write new key to vault
 /// 6. Write new key ID to vault (if provider returned one)
-///    6.5. Apply post-rotation sync hook (if `[sync.*]` configured)
-/// 7. Append log entry
+/// 7. Apply post-rotation sync hook (if `[sync.*]` configured)
+/// 8. Run `post_rotate` user hooks (warn-on-failure)
+/// 9. Run `verify` gate (strict — Err on failure)
+/// 10. Append log entry
 pub async fn execute(
     store: &PassageStore,
     provider_name: &str,
     provider_config: &ProviderConfig,
 ) -> anyhow::Result<()> {
-    // 1. Read current key
-    let current_key = store
-        .get(&provider_config.secret_path)
-        .map_err(|e| anyhow::anyhow!("cannot read '{}': {e}", provider_config.secret_path))?;
-
-    // 2. Read stored key ID from the previous rotation (optional)
     let id_path = key_id_path(&provider_config.secret_path);
-    let old_key_id = store
-        .get(&id_path)
-        .ok()
-        .map(|s| s.expose_secret().to_string());
+    let is_local = provider_config.settings.get("type").map(String::as_str) == Some("local");
+
+    // 1-2. Read current key + previous key ID (skipped for `type=local`,
+    //      whose generator doesn't depend on prior state — first-rotation
+    //      cases would otherwise fail when the path is empty).
+    let (current_key_for_provider, old_key_id) = if is_local {
+        (SecretString::from(String::new()), None)
+    } else {
+        let current = store
+            .get(&provider_config.secret_path)
+            .map_err(|e| anyhow::anyhow!("cannot read '{}': {e}", provider_config.secret_path))?;
+        let id = store
+            .get(&id_path)
+            .ok()
+            .map(|s| s.expose_secret().to_string());
+        (SecretString::from(current.expose_secret().to_string()), id)
+    };
 
     // 3. Build provider via factory dispatch on settings["type"].
     let provider = build_provider(
         store,
         provider_name.to_string(),
-        SecretString::from(current_key.expose_secret().to_string()),
+        current_key_for_provider,
         old_key_id,
         &provider_config.settings,
     )?;
@@ -79,7 +99,7 @@ pub async fn execute(
             .map_err(|e| anyhow::anyhow!("cannot write key ID to vault: {e}"))?;
     }
 
-    // 6.5. Post-rotation sync hook. The vault is already on the
+    // 7. Post-rotation sync hook. The vault is already on the
     // new value at this point; sync is best-effort and infallible
     // at the function level (failures land as log entries). We
     // surface partial failures to stderr so the operator knows to
@@ -107,13 +127,98 @@ pub async fn execute(
         None
     };
 
-    // 7. Append log entry
+    // 8. post_rotate user hooks (warn-on-failure)
+    for cmd in &provider_config.post_rotate {
+        eprintln!("  Running post_rotate: {cmd}");
+        match tokio::process::Command::new("sh")
+            .args(["-c", cmd])
+            .output()
+            .await
+        {
+            Ok(output) if output.status.success() => {
+                eprintln!("  ✓ post_rotate succeeded: {cmd}");
+            }
+            Ok(output) => {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                eprintln!(
+                    "  ⚠ post_rotate command failed (exit {}): {cmd}\n    {}",
+                    output.status.code().unwrap_or(-1),
+                    stderr.trim()
+                );
+            }
+            Err(e) => {
+                eprintln!("  ⚠ post_rotate command could not be executed: {cmd}\n    {e}");
+            }
+        }
+    }
+
+    // 9. verify gate (STRICT — Err on failure)
+    let verified: Option<bool> = match &provider_config.verify {
+        None => None,
+        Some(verify_cmd) => {
+            eprintln!("  Running verify: {verify_cmd}");
+            match tokio::process::Command::new("sh")
+                .args(["-c", verify_cmd])
+                .output()
+                .await
+            {
+                Ok(output) if output.status.success() => {
+                    eprintln!("  ✓ Verification passed for '{provider_name}'");
+                    Some(true)
+                }
+                Ok(output) => {
+                    let exit_code = output.status.code().unwrap_or(-1);
+                    let stderr = String::from_utf8_lossy(&output.stderr);
+                    let stderr_trim = stderr.trim();
+
+                    // Write log entry with verified=Some(false) BEFORE returning Err
+                    // so the audit trail records the failed verification.
+                    append_log(
+                        store,
+                        provider_name,
+                        &provider_config.secret_path,
+                        &outcome.new_key_id,
+                        sync_log,
+                        Some(false),
+                    )?;
+
+                    eprintln!(
+                        "  ✗ Verification FAILED for '{provider_name}' (exit {exit_code}): {stderr_trim}"
+                    );
+                    return Err(anyhow::anyhow!(
+                        "verify command exited non-zero (code {exit_code}): {verify_cmd}"
+                    ));
+                }
+                Err(e) => {
+                    // Spawn / I/O failure — also strict.
+                    append_log(
+                        store,
+                        provider_name,
+                        &provider_config.secret_path,
+                        &outcome.new_key_id,
+                        sync_log,
+                        Some(false),
+                    )?;
+
+                    eprintln!(
+                        "  ✗ Verify command could not be executed for '{provider_name}': {e}"
+                    );
+                    return Err(anyhow::anyhow!(
+                        "verify command could not be executed: {verify_cmd}: {e}"
+                    ));
+                }
+            }
+        }
+    };
+
+    // 10. Append log entry (success path)
     append_log(
         store,
         provider_name,
         &provider_config.secret_path,
         &outcome.new_key_id,
         sync_log,
+        verified,
     )?;
 
     eprintln!(
@@ -133,20 +238,26 @@ pub async fn dry_run(
     provider_name: &str,
     provider_config: &ProviderConfig,
 ) -> anyhow::Result<()> {
-    let current_key = store
-        .get(&provider_config.secret_path)
-        .map_err(|e| anyhow::anyhow!("cannot read '{}': {e}", provider_config.secret_path))?;
-
     let id_path = key_id_path(&provider_config.secret_path);
-    let old_key_id = store
-        .get(&id_path)
-        .ok()
-        .map(|s| s.expose_secret().to_string());
+    let is_local = provider_config.settings.get("type").map(String::as_str) == Some("local");
+
+    let (current_key_for_provider, old_key_id) = if is_local {
+        (SecretString::from(String::new()), None)
+    } else {
+        let current = store
+            .get(&provider_config.secret_path)
+            .map_err(|e| anyhow::anyhow!("cannot read '{}': {e}", provider_config.secret_path))?;
+        let id = store
+            .get(&id_path)
+            .ok()
+            .map(|s| s.expose_secret().to_string());
+        (SecretString::from(current.expose_secret().to_string()), id)
+    };
 
     let provider = build_provider(
         store,
         provider_name.to_string(),
-        SecretString::from(current_key.expose_secret().to_string()),
+        current_key_for_provider,
         old_key_id,
         &provider_config.settings,
     )?;
@@ -155,6 +266,25 @@ pub async fn dry_run(
 
     let plan = provider.dry_run().await?;
     eprintln!("[dry run] Rotation plan for provider '{provider_name}':\n{plan}");
+
+    if !provider_config.post_rotate.is_empty() {
+        eprintln!(
+            "[dry run] post_rotate hooks ({} command{}):",
+            provider_config.post_rotate.len(),
+            if provider_config.post_rotate.len() == 1 {
+                ""
+            } else {
+                "s"
+            }
+        );
+        for cmd in &provider_config.post_rotate {
+            eprintln!("  - {cmd}");
+        }
+    }
+
+    if let Some(ref verify_cmd) = provider_config.verify {
+        eprintln!("[dry run] verify (strict): {verify_cmd}");
+    }
 
     Ok(())
 }
@@ -165,6 +295,7 @@ fn append_log(
     secret_path: &str,
     new_key_id: &Option<String>,
     sync: Option<Vec<SyncLogEntry>>,
+    verified: Option<bool>,
 ) -> anyhow::Result<()> {
     let log_dir = store.store_dir().join(".revvault");
     std::fs::create_dir_all(&log_dir)?;
@@ -182,6 +313,7 @@ fn append_log(
         new_key_id: new_key_id.clone(),
         status: "success".into(),
         sync,
+        verified,
     };
 
     let line = serde_json::to_string(&entry)?;

--- a/crates/core/src/rotation/mod.rs
+++ b/crates/core/src/rotation/mod.rs
@@ -1,19 +1,25 @@
 //! Secret rotation engine.
 //!
 //! Provides rotation providers and an executor that orchestrates vault
-//! I/O around provider dispatch (factory in `providers::build_provider`).
+//! I/O around provider dispatch (factory in `providers::build_provider`),
+//! the post-rotation Vercel sync hook (`sync_hook`), user-configurable
+//! `post_rotate` shell hooks, and a strict `verify` gate.
 //!
 //! # Supported providers
 //!
 //! - `GenericHttpProvider` — any API key lifecycle driven by two HTTP
 //!   endpoints (create + optional revoke). Default when `settings["type"]`
 //!   is unset; works for stripe / vercel / github tokens whose auth is
-//!   the value being rotated. Configured via
-//!   `<store>/.revvault/rotation.toml`.
+//!   the value being rotated.
 //! - `NeonProvider` — Neon Postgres password reset. Selected by
 //!   `settings["type"] = "neon"`. Reads its API key from a separate vault
 //!   path (`settings["api_key_path"]`) because the rotated value (the
 //!   connection URI) is distinct from the auth token.
+//! - `LocalGeneratorProvider` — cryptographically random values
+//!   (hex32 / hex64 / uuid) without network calls. Selected by
+//!   `settings["type"] = "local"` with `settings["generator_type"]`.
+//!
+//! All providers configured via `<store>/.revvault/rotation.toml`.
 
 pub mod config;
 pub mod executor;

--- a/crates/core/src/rotation/provider.rs
+++ b/crates/core/src/rotation/provider.rs
@@ -30,6 +30,13 @@ pub struct RotationLogEntry {
     /// vector when sync ran but nothing to do.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sync: Option<Vec<SyncLogEntry>>,
+    /// Whether the post-rotation `verify` command passed.
+    /// `None` when no verify command was configured;
+    /// `Some(true)` when verify exited zero;
+    /// `Some(false)` when verify failed (the executor also
+    /// returns Err in that case so the cli exits non-zero).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verified: Option<bool>,
 }
 
 /// Trait for secret rotation providers.

--- a/crates/core/src/rotation/providers/local.rs
+++ b/crates/core/src/rotation/providers/local.rs
@@ -1,0 +1,102 @@
+//! Local secret generator — produces cryptographically random values without
+//! any network calls. Used for internal secrets like REVEALUI_SECRET.
+
+use std::str::FromStr;
+
+use async_trait::async_trait;
+use rand::RngCore;
+use secrecy::SecretString;
+
+use crate::error::{Result, RevvaultError};
+use crate::rotation::provider::{RotationOutcome, RotationProvider};
+
+/// The type of value to generate.
+#[derive(Debug)]
+pub enum GeneratorType {
+    /// 32-byte hex string (64 hex chars).
+    Hex32,
+    /// 64-byte hex string (128 hex chars).
+    Hex64,
+    /// UUID v4 string.
+    Uuid,
+}
+
+impl FromStr for GeneratorType {
+    type Err = RevvaultError;
+
+    /// Parse a generator type from a string (as used in `rotation.toml` settings).
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "hex32" => Ok(Self::Hex32),
+            "hex64" => Ok(Self::Hex64),
+            "uuid" => Ok(Self::Uuid),
+            other => Err(RevvaultError::Other(anyhow::anyhow!(
+                "unknown generator_type: '{other}' (expected hex32, hex64, or uuid)"
+            ))),
+        }
+    }
+}
+
+impl GeneratorType {
+    /// Generate a random value of this type.
+    fn generate(&self) -> String {
+        match self {
+            Self::Hex32 => {
+                let mut bytes = [0u8; 32];
+                rand::rng().fill_bytes(&mut bytes);
+                hex::encode(bytes)
+            }
+            Self::Hex64 => {
+                let mut bytes = [0u8; 64];
+                rand::rng().fill_bytes(&mut bytes);
+                hex::encode(bytes)
+            }
+            Self::Uuid => uuid::Uuid::new_v4().to_string(),
+        }
+    }
+}
+
+/// Local secret generator provider — no network, no API keys.
+#[derive(Debug)]
+pub struct LocalGeneratorProvider {
+    name: String,
+    generator_type: GeneratorType,
+}
+
+impl LocalGeneratorProvider {
+    /// Create a new local generator provider.
+    ///
+    /// `generator_type_str` must be one of `"hex32"`, `"hex64"`, or `"uuid"`.
+    pub fn new(name: String, generator_type_str: &str) -> Result<Self> {
+        Ok(Self {
+            name,
+            generator_type: GeneratorType::from_str(generator_type_str)?,
+        })
+    }
+}
+
+#[async_trait]
+impl RotationProvider for LocalGeneratorProvider {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    async fn preflight(&self) -> Result<()> {
+        Ok(())
+    }
+
+    async fn rotate(&self) -> Result<RotationOutcome> {
+        let value = self.generator_type.generate();
+        Ok(RotationOutcome {
+            new_value: SecretString::from(value),
+            new_key_id: None,
+        })
+    }
+
+    async fn dry_run(&self) -> Result<String> {
+        Ok(format!(
+            "Provider '{}': generate {:?} value (no network call)",
+            self.name, self.generator_type
+        ))
+    }
+}

--- a/crates/core/src/rotation/providers/mod.rs
+++ b/crates/core/src/rotation/providers/mod.rs
@@ -5,16 +5,20 @@
 //! `settings["type"]` so the executor doesn't need to know which kind of
 //! provider it's running.
 //!
-//! - `type` absent or any value other than `"neon"` → [`GenericHttpProvider`]
+//! - `type` absent or any unrecognized value → [`GenericHttpProvider`]
 //!   (HTTP create + optional revoke pattern; works for stripe / vercel /
 //!   github tokens whose auth is the value being rotated).
 //! - `type = "neon"` → [`NeonProvider`] (Neon Postgres password reset; the
 //!   auth token is a separate vault secret read from `api_key_path`).
+//! - `type = "local"` → [`LocalGeneratorProvider`] (cryptographically
+//!   random value via `generator_type = hex32 | hex64 | uuid`; no network).
 
 pub mod http;
+pub mod local;
 pub mod neon;
 
 pub use http::GenericHttpProvider;
+pub use local::LocalGeneratorProvider;
 pub use neon::NeonProvider;
 
 use std::collections::HashMap;
@@ -32,6 +36,10 @@ use crate::store::PassageStore;
 ///   the vault path in `settings["api_key_path"]` so the rotated value
 ///   (the connection URI at `secret_path`) and the auth token can live in
 ///   different vault locations.
+/// - `"local"` — constructs a `LocalGeneratorProvider`. Reads
+///   `settings["generator_type"]` (one of `hex32` / `hex64` / `uuid`).
+///   `current_key` and `old_key_id` are unused — local secrets have no
+///   external lifecycle to track.
 /// - anything else (or absent) — constructs a `GenericHttpProvider` using
 ///   `current_key` as the auth token and the existing create/revoke URL
 ///   pattern.
@@ -66,6 +74,15 @@ pub fn build_provider(
                 api_key_owned,
                 settings,
             )?))
+        }
+        Some("local") => {
+            let gen_type = settings.get("generator_type").ok_or_else(|| {
+                RevvaultError::Other(anyhow::anyhow!(
+                    "provider '{}': type=local requires 'generator_type' setting (one of: hex32, hex64, uuid)",
+                    name
+                ))
+            })?;
+            Ok(Box::new(LocalGeneratorProvider::new(name, gen_type)?))
         }
         _ => Ok(Box::new(GenericHttpProvider::from_config(
             name,

--- a/crates/core/tests/rotation_integration.rs
+++ b/crates/core/tests/rotation_integration.rs
@@ -602,14 +602,19 @@ async fn executor_runs_post_rotate_hooks_in_order() {
     let tmp = tempfile::tempdir().unwrap();
     let marker_a = tmp.path().join("a");
     let marker_b = tmp.path().join("b");
+    // Convert to forward-slashes + single-quote so the path round-trips through
+    // `sh -c` on both Unix and Git Bash on Windows (which mangles backslashes
+    // in unquoted argv).
+    let marker_a_sh = marker_a.to_string_lossy().replace('\\', "/");
+    let marker_b_sh = marker_b.to_string_lossy().replace('\\', "/");
 
     let provider_config = revvault_core::rotation::config::ProviderConfig {
         secret_path: "credentials/internal/seq-secret".into(),
         settings: settings(&[("type", "local"), ("generator_type", "hex32")]),
         sync: None,
         post_rotate: vec![
-            format!("touch {}", marker_a.display()),
-            format!("touch {}", marker_b.display()),
+            format!("touch '{marker_a_sh}'"),
+            format!("touch '{marker_b_sh}'"),
         ],
         verify: None,
     };
@@ -743,12 +748,13 @@ async fn executor_verify_failure_with_post_rotate_still_runs_post_rotate() {
 
     let tmp = tempfile::tempdir().unwrap();
     let marker = tmp.path().join("ran");
+    let marker_sh = marker.to_string_lossy().replace('\\', "/");
 
     let provider_config = revvault_core::rotation::config::ProviderConfig {
         secret_path: "credentials/internal/seq-and-fail".into(),
         settings: settings(&[("type", "local"), ("generator_type", "hex32")]),
         sync: None,
-        post_rotate: vec![format!("touch {}", marker.display())],
+        post_rotate: vec![format!("touch '{marker_sh}'")],
         verify: Some("false".into()), // exits 1 — strict failure
     };
 

--- a/crates/core/tests/rotation_integration.rs
+++ b/crates/core/tests/rotation_integration.rs
@@ -396,6 +396,8 @@ async fn executor_writes_new_key_to_vault_and_logs() {
             ("id_field", "tokenId"),
         ]),
         sync: None,
+        post_rotate: vec![],
+        verify: None,
     };
 
     executor::execute(&store, "svc", &provider_config)
@@ -458,6 +460,8 @@ async fn executor_uses_stored_key_id_for_revocation() {
             ),
         ]),
         sync: None,
+        post_rotate: vec![],
+        verify: None,
     };
 
     executor::execute(&store, "svc", &provider_config)
@@ -467,4 +471,295 @@ async fn executor_uses_stored_key_id_for_revocation() {
     _revoke.assert_async().await;
     let new_key = store.get("credentials/svc/token").unwrap();
     assert_eq!(new_key.expose_secret(), "next-key");
+}
+
+// ---------------------------------------------------------------------------
+// LocalGeneratorProvider — type=local + generator_type
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn executor_local_hex32_writes_64_hex_chars_to_vault() {
+    let (_dir, store) = setup_store();
+
+    let provider_config = revvault_core::rotation::config::ProviderConfig {
+        secret_path: "credentials/internal/session-secret".into(),
+        settings: settings(&[("type", "local"), ("generator_type", "hex32")]),
+        sync: None,
+        post_rotate: vec![],
+        verify: None,
+    };
+
+    executor::execute(&store, "internal", &provider_config)
+        .await
+        .unwrap();
+
+    let new_value = store.get("credentials/internal/session-secret").unwrap();
+    let s = new_value.expose_secret();
+    assert_eq!(s.len(), 64, "hex32 = 32 bytes = 64 hex chars");
+    assert!(
+        s.chars().all(|c| c.is_ascii_hexdigit()),
+        "all chars must be hex"
+    );
+}
+
+#[tokio::test]
+async fn executor_local_hex64_writes_128_hex_chars_to_vault() {
+    let (_dir, store) = setup_store();
+
+    let provider_config = revvault_core::rotation::config::ProviderConfig {
+        secret_path: "credentials/internal/double-secret".into(),
+        settings: settings(&[("type", "local"), ("generator_type", "hex64")]),
+        sync: None,
+        post_rotate: vec![],
+        verify: None,
+    };
+
+    executor::execute(&store, "internal", &provider_config)
+        .await
+        .unwrap();
+
+    let new_value = store.get("credentials/internal/double-secret").unwrap();
+    let s = new_value.expose_secret();
+    assert_eq!(s.len(), 128, "hex64 = 64 bytes = 128 hex chars");
+    assert!(s.chars().all(|c| c.is_ascii_hexdigit()));
+}
+
+#[tokio::test]
+async fn executor_local_uuid_writes_uuid_v4_to_vault() {
+    let (_dir, store) = setup_store();
+
+    let provider_config = revvault_core::rotation::config::ProviderConfig {
+        secret_path: "credentials/internal/req-id".into(),
+        settings: settings(&[("type", "local"), ("generator_type", "uuid")]),
+        sync: None,
+        post_rotate: vec![],
+        verify: None,
+    };
+
+    executor::execute(&store, "internal", &provider_config)
+        .await
+        .unwrap();
+
+    let new_value = store.get("credentials/internal/req-id").unwrap();
+    let s = new_value.expose_secret();
+    // UUID v4 canonical: 8-4-4-4-12 = 36 chars including 4 hyphens
+    assert_eq!(s.len(), 36);
+    assert_eq!(s.chars().filter(|c| *c == '-').count(), 4);
+    // Version nibble must be '4' for UUID v4
+    let v_nibble = s.chars().nth(14).expect("uuid index 14 = version nibble");
+    assert_eq!(v_nibble, '4', "UUID v4 should have '4' at position 14");
+}
+
+#[tokio::test]
+async fn local_factory_rejects_missing_generator_type() {
+    let (_dir, store) = setup_store();
+
+    let provider_config = revvault_core::rotation::config::ProviderConfig {
+        secret_path: "credentials/internal/x".into(),
+        settings: settings(&[("type", "local")]),
+        sync: None,
+        post_rotate: vec![],
+        verify: None,
+    };
+
+    let err = executor::execute(&store, "internal", &provider_config)
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("generator_type"),
+        "error should mention missing generator_type setting: {err}"
+    );
+}
+
+#[tokio::test]
+async fn local_factory_rejects_unknown_generator_type() {
+    let (_dir, store) = setup_store();
+
+    let provider_config = revvault_core::rotation::config::ProviderConfig {
+        secret_path: "credentials/internal/x".into(),
+        settings: settings(&[("type", "local"), ("generator_type", "bogus")]),
+        sync: None,
+        post_rotate: vec![],
+        verify: None,
+    };
+
+    let err = executor::execute(&store, "internal", &provider_config)
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("generator_type"));
+}
+
+// ---------------------------------------------------------------------------
+// post_rotate user hooks — warn-on-failure
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn executor_runs_post_rotate_hooks_in_order() {
+    let (_dir, store) = setup_store();
+
+    // Use temp files to verify hook execution order without depending on
+    // observable side effects in the vault itself.
+    let tmp = tempfile::tempdir().unwrap();
+    let marker_a = tmp.path().join("a");
+    let marker_b = tmp.path().join("b");
+
+    let provider_config = revvault_core::rotation::config::ProviderConfig {
+        secret_path: "credentials/internal/seq-secret".into(),
+        settings: settings(&[("type", "local"), ("generator_type", "hex32")]),
+        sync: None,
+        post_rotate: vec![
+            format!("touch {}", marker_a.display()),
+            format!("touch {}", marker_b.display()),
+        ],
+        verify: None,
+    };
+
+    executor::execute(&store, "seq", &provider_config)
+        .await
+        .unwrap();
+
+    assert!(marker_a.exists(), "first hook should have run");
+    assert!(marker_b.exists(), "second hook should have run");
+}
+
+#[tokio::test]
+async fn executor_post_rotate_failure_does_not_abort_rotation() {
+    let (_dir, store) = setup_store();
+
+    let provider_config = revvault_core::rotation::config::ProviderConfig {
+        secret_path: "credentials/internal/hookfail-secret".into(),
+        settings: settings(&[("type", "local"), ("generator_type", "hex32")]),
+        sync: None,
+        post_rotate: vec!["false".into()], // exits 1
+        verify: None,
+    };
+
+    // post_rotate hook is warn-only, so this must succeed.
+    executor::execute(&store, "hookfail", &provider_config)
+        .await
+        .unwrap();
+
+    // And the vault must hold the rotated value.
+    let v = store.get("credentials/internal/hookfail-secret").unwrap();
+    assert_eq!(v.expose_secret().len(), 64, "hex32 was written");
+
+    // Log entry written successfully.
+    let log_path = store.store_dir().join(".revvault/rotation-log.jsonl");
+    assert!(log_path.exists());
+}
+
+// ---------------------------------------------------------------------------
+// verify gate — STRICT (Err on failure, log records verified=false)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn executor_verify_success_logs_verified_true() {
+    let (_dir, store) = setup_store();
+
+    let provider_config = revvault_core::rotation::config::ProviderConfig {
+        secret_path: "credentials/internal/verify-ok".into(),
+        settings: settings(&[("type", "local"), ("generator_type", "hex32")]),
+        sync: None,
+        post_rotate: vec![],
+        verify: Some("true".into()), // exits 0
+    };
+
+    executor::execute(&store, "verify-ok", &provider_config)
+        .await
+        .unwrap();
+
+    let log_path = store.store_dir().join(".revvault/rotation-log.jsonl");
+    let log = std::fs::read_to_string(&log_path).unwrap();
+    assert!(log.contains(r#""verified":true"#), "log was: {log}");
+}
+
+#[tokio::test]
+async fn executor_no_verify_omits_verified_field_in_log() {
+    let (_dir, store) = setup_store();
+
+    let provider_config = revvault_core::rotation::config::ProviderConfig {
+        secret_path: "credentials/internal/no-verify".into(),
+        settings: settings(&[("type", "local"), ("generator_type", "hex32")]),
+        sync: None,
+        post_rotate: vec![],
+        verify: None,
+    };
+
+    executor::execute(&store, "no-verify", &provider_config)
+        .await
+        .unwrap();
+
+    let log_path = store.store_dir().join(".revvault/rotation-log.jsonl");
+    let log = std::fs::read_to_string(&log_path).unwrap();
+    // skip_serializing_if = "Option::is_none" means the field must be absent,
+    // not present-as-null.
+    assert!(
+        !log.contains("\"verified\""),
+        "verified field should be omitted when None; log was: {log}"
+    );
+}
+
+#[tokio::test]
+async fn executor_verify_failure_returns_err_and_logs_verified_false() {
+    let (_dir, store) = setup_store();
+
+    let provider_config = revvault_core::rotation::config::ProviderConfig {
+        secret_path: "credentials/internal/verify-fail".into(),
+        settings: settings(&[("type", "local"), ("generator_type", "hex32")]),
+        sync: None,
+        post_rotate: vec![],
+        verify: Some("false".into()), // exits 1
+    };
+
+    let err = executor::execute(&store, "verify-fail", &provider_config)
+        .await
+        .unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("verify command exited non-zero"),
+        "error message should say verify failed: {msg}"
+    );
+
+    // Vault still has the rotated value (the rotation already landed).
+    let v = store.get("credentials/internal/verify-fail").unwrap();
+    assert_eq!(v.expose_secret().len(), 64);
+
+    // Log entry was written with verified=false BEFORE returning Err.
+    let log_path = store.store_dir().join(".revvault/rotation-log.jsonl");
+    assert!(
+        log_path.exists(),
+        "log file should be created on verify fail"
+    );
+    let log = std::fs::read_to_string(&log_path).unwrap();
+    assert!(
+        log.contains(r#""verified":false"#),
+        "log entry should record verified:false; log was: {log}"
+    );
+}
+
+#[tokio::test]
+async fn executor_verify_failure_with_post_rotate_still_runs_post_rotate() {
+    let (_dir, store) = setup_store();
+
+    let tmp = tempfile::tempdir().unwrap();
+    let marker = tmp.path().join("ran");
+
+    let provider_config = revvault_core::rotation::config::ProviderConfig {
+        secret_path: "credentials/internal/seq-and-fail".into(),
+        settings: settings(&[("type", "local"), ("generator_type", "hex32")]),
+        sync: None,
+        post_rotate: vec![format!("touch {}", marker.display())],
+        verify: Some("false".into()), // exits 1 — strict failure
+    };
+
+    let _err = executor::execute(&store, "seq-and-fail", &provider_config)
+        .await
+        .unwrap_err();
+
+    // post_rotate runs BEFORE verify, so the marker should exist even though
+    // verify failed.
+    assert!(
+        marker.exists(),
+        "post_rotate (step 8) runs before verify (step 9), so marker should exist even when verify fails"
+    );
 }


### PR DESCRIPTION
## Summary

Fresh-branch rebuild of the rotation enhancements that were originally on `feat/rotation-engine-enhancements` (PR #36, superseded). The original branch was 25 commits behind main and contained an `add/add` conflict with `crates/cli/src/commands/sync.rs` — main shipped a more sophisticated sync command via [revvault#19](https://github.com/RevealUIStudio/revvault/pull/19) (GAP-157 Phase 1+2) that extracted `VercelClient` to `core::sync::vercel` with retry-on-429 + mockito-injectable `with_base_url()`. Per [the triage comment on #36](https://github.com/RevealUIStudio/revvault/pull/36#issuecomment-4368390156), this branch carries only the additive rotation work onto current `main`.

**Supersedes [#36](https://github.com/RevealUIStudio/revvault/pull/36).**

## Hook order (owner-decided)

```
vault-write → sync_hook → post_rotate → verify → log-append
```

- `apply_sync_after_rotation` (existing main): infallible, per-target log rows.
- `post_rotate` (NEW): user shell commands, **warn-on-failure** (key is already in vault, hooks are best-effort).
- `verify` (NEW): **STRICT** — exit-non-zero writes `verified: false` to the log AND causes the executor to return `Err` so the cli exits non-zero. Vault state is unchanged either way.

## What's added

| Surface | What |
| --- | --- |
| `ProviderConfig` | `post_rotate: Vec<String>` + `verify: Option<String>`, both `#[serde(default)]` |
| `RotationLogEntry` | `verified: Option<bool>` alongside existing `sync` field. `None` = not configured, `Some(true)` = passed, `Some(false)` = failed |
| `crates/core/src/rotation/providers/local.rs` | NEW `LocalGeneratorProvider` (hex32 / hex64 / uuid v4 via `rand` + `hex` + `uuid`); `GeneratorType` implements `std::str::FromStr` |
| `providers/mod.rs` factory | `type = "local"` arm; reads `generator_type` from settings |
| `executor.rs` | Skips `current_key` + `old_key_id` reads for `type=local` (generator has no prior-state dependency); composes `post_rotate` (warn) and `verify` (strict) with main's existing `sync_hook` step; `dry_run` prints configured hooks + verify cmd |
| Workspace `Cargo.toml` | `hex = "0.4"` + `uuid = { version = "1", features = ["v4"] }` |
| `crates/core/Cargo.toml` | `rand`, `hex`, `uuid` (workspace deps) |

## What's dropped from PR #36

| Surface | Reason |
| --- | --- |
| `crates/cli/src/commands/sync.rs` | Superseded by main's GAP-157 Phase 1+2 ([revvault#19](https://github.com/RevealUIStudio/revvault/pull/19)) — main's implementation has retry-on-429 + mockito injection + the cli code is -159 LOC |
| `chore: remove Claude files from public repo tracking` | Moot — main already gitignores `CLAUDE.md` + `.claude/` |
| `chore: update Cargo.lock` | Regenerates on rebase |
| Accidental drop of `rust-version.workspace = true` | Preserved main's line |

## Test plan

- [x] `cargo check --workspace --tests` — clean (1m 35s first build)
- [x] `cargo test --workspace` — **all green**:
  - `rotation_integration`: **26/26** (was 15; +11 new tests)
  - `sync_hook` unit tests: 27/27
  - lib unit tests: 58/58
  - `store_integration`: 4/4 (1 `#[ignore]` baseline)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

### New test coverage (11 tests)

- `executor_local_hex32_writes_64_hex_chars_to_vault`
- `executor_local_hex64_writes_128_hex_chars_to_vault`
- `executor_local_uuid_writes_uuid_v4_to_vault` (asserts version nibble = `4`)
- `local_factory_rejects_missing_generator_type`
- `local_factory_rejects_unknown_generator_type`
- `executor_runs_post_rotate_hooks_in_order`
- `executor_post_rotate_failure_does_not_abort_rotation`
- `executor_verify_success_logs_verified_true`
- `executor_no_verify_omits_verified_field_in_log`
- `executor_verify_failure_returns_err_and_logs_verified_false`
- `executor_verify_failure_with_post_rotate_still_runs_post_rotate` (step ordering)

## Migration / compatibility

- `RotationLogEntry.verified` uses `#[serde(skip_serializing_if = "Option::is_none")]` — existing log entries (no verify) remain readable; new entries omit the field unless verify ran.
- `ProviderConfig.post_rotate` defaults to empty `Vec<String>`; existing `rotation.toml` files unaffected.
- `ProviderConfig.verify` defaults to `None`; existing files unaffected.
- New `type = "local"` is purely additive; existing `type = "neon"` and unspecified-type configs unchanged.

## Out of scope

- The branch's `finish_rotation()` extraction was not carried across — main's executor is already cleanly structured around `apply_sync_after_rotation` and the new steps inline cleanly. Refactoring for refactoring's sake would be premature.
- Provider lifecycle for `type=local` ignores `current_key` + `old_key_id`. If a future use case wants local-with-prior-state semantics, that's a follow-up.
