### PR TITLE
chore(docs): rename ~/suite/ -> ~/revfleet/ in CLAUDE.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,33 @@
+# Revvault
+
+Age-encrypted secret vault with CLI and Tauri desktop app.
+
+## Architecture
+
+- `crates/core` — shared library (store, crypto, identity, config, namespaces, import, rotation)
+- `crates/cli` — `revvault` CLI binary (clap)
+- `crates/tauri-app` — Tauri 2 desktop backend
+- `frontend/` — React 19 + TypeScript + Tailwind CSS (Vite)
+
+## Build
+
+Requires Nix with flakes enabled. From WSL:
+
+```bash
+cd ~/revfleet/revvault
+direnv allow  # or: nix develop
+cargo build --workspace
+cargo tauri dev
+```
+
+## Store Format
+
+100% passage-compatible. Secrets stored as `.age` files in a directory hierarchy.
+Default store: `~/.revealui/passage-store`. Override with `REVVAULT_STORE` env var.
+
+## Conventions
+
+- Rust edition 2021, stable channel
+- `thiserror` for library errors, `anyhow` for binary/CLI errors
+- `secrecy::SecretString` for decrypted values in memory
+- Frontend uses Tailwind v4 (CSS import, no config file)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,33 @@
+# Revvault
+
+Age-encrypted secret vault with CLI and Tauri desktop app.
+
+## Architecture
+
+- `crates/core` — shared library (store, crypto, identity, config, namespaces, import, rotation)
+- `crates/cli` — `revvault` CLI binary (clap)
+- `crates/tauri-app` — Tauri 2 desktop backend
+- `frontend/` — React 19 + TypeScript + Tailwind CSS (Vite)
+
+## Build
+
+Requires Nix with flakes enabled. From WSL:
+
+```bash
+cd ~/revfleet/revvault
+direnv allow  # or: nix develop
+cargo build --workspace
+cargo tauri dev
+```
+
+## Store Format
+
+100% passage-compatible. Secrets stored as `.age` files in a directory hierarchy.
+Default store: `~/.revealui/passage-store`. Override with `REVVAULT_STORE` env var.
+
+## Conventions
+
+- Rust edition 2021, stable channel
+- `thiserror` for library errors, `anyhow` for binary/CLI errors
+- `secrecy::SecretString` for decrypted values in memory
+- Frontend uses Tailwind v4 (CSS import, no config file)


### PR DESCRIPTION
## Summary

Phase D-2 doc-quality rename sweep — ~/suite/revvault → ~/revfleet/revvault in CLAUDE.md L17 and the duplicated .claude/CLAUDE.md L17.

Per fleet doc-quality audit at internal docs (committed ^[0a59018c on an internal repo:main).

## Audit context

Part of Phase D-2 residual fleet-wide rename sweep. README.md (2026-03-18, oldest in fleet) is keep — content stable. Only the CLAUDE.md path examples need refresh; .claude/CLAUDE.md appears to be a synced duplicate (same fix applied to both).

## Test plan

- [ ] Doc-only change
- [ ] CI green expected
- [ ] Path examples now resolve correctly post-rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)