### PR TITLE
docs(planning): add MASTER_PLAN.md + MASTER_SPEC.md

### DIFF
--- a/docs/MASTER_PLAN.md
+++ b/docs/MASTER_PLAN.md
@@ -1,0 +1,130 @@
+# RevVault — Master Plan
+
+**Last Updated:** 2026-05-10
+**Status:** Active — production-grade for studio internal use; commercial offering wraps RevealUI Pro tier
+**Owner:** RevealUI Studio (`founder@revealui.com`)
+**Repo:** [RevealUIStudio/revvault](https://github.com/RevealUIStudio/revvault)
+**Fleet master index:** [`revealui-jv:docs/MASTER_INDEX.md`](https://github.com/RevealUIStudio/revealui-jv/blob/main/docs/MASTER_INDEX.md)
+
+> Fleet-level cross-cutting plans live in [`revealui-jv:docs/MASTER_PLAN.md`](https://github.com/RevealUIStudio/revealui-jv/blob/main/docs/MASTER_PLAN.md). This file is RevVault-scoped only.
+
+---
+
+## Current Reality (2026-05-10)
+
+### What exists
+
+- **Cargo workspace** with 3 crates: `cli`, `core`, `tauri-app`
+- **Frontend** (Tauri 2 + React 19) at `frontend/`
+- **Encryption**: age x25519 keys via the user's `~/.age-identity/keys.txt`; secrets stored as `.age` files
+- **CLI commands**: `get`, `set`, `list`, `search`, `delete`, `edit`, `export-env`, `generate` (added 2026-04-x via #26)
+- **Sync**: Vercel sync surface; per-var vault-path overrides land via `feat/sync-per-var-path-override`
+- **Rotation**: post-rotate hooks + strict verify + local generator (#37 merged)
+- **CI**: SHA-pinned 37 actions (#34); Tauri cross-platform build workflow (#35)
+- **Path validation**: directory traversal + injection attacks blocked at the API layer
+
+### What works (verified by code + commit history)
+
+| Capability | Status | Confidence |
+|---|---|---|
+| `revvault get/set/list/delete` (file-based age vault) | Built | High — production-grade for studio internal use |
+| Fuzzy search over secret paths | Built | High |
+| `export-env` materialization for direnv | Built | High |
+| Tauri desktop UI (search, browse, reveal, copy, delete) | Built | Medium — used internally; not packaged for external customers yet |
+| Vercel sync (manifest-driven, per-var path overrides) | Active | Medium — new path-override feature on `feat/sync-per-var-path-override` |
+| Rotation engine + post-rotate hooks | Built | Medium — shipped via #37 |
+| Path validation (traversal/injection) | Built | High |
+| `generate` subcommand for strong passwords | Built | High — shipped via #26 |
+
+### What does not exist yet
+
+- Public Tauri desktop releases (no signed/notarized auto-update pipeline cutting public releases)
+- Cross-machine sync over a server (vault is single-machine; Vercel sync is one-way write to deployment env)
+- Multi-identity vaults (single age identity per machine; team-shared identities not yet modeled)
+- Audit log for `get`/`set` operations
+- `revvault status` cross-check against revealui's `.env.example` (drift warning)
+
+---
+
+## Composition with the rest of RevFleet
+
+RevVault is the **source of truth for every secret** in RevFleet per [`revealui:.claude/rules/secrets.md`](https://github.com/RevealUIStudio/revealui/blob/main/.claude/rules/secrets.md). One sentence trust story:
+
+> Secrets live in RevVault, encrypted by an age identity that doesn't leave the developer's machine.
+
+- **Local dev**: `revvault export-env` materializes `.env`-shaped output that direnv loads at session start
+- **CI**: GitHub Actions secrets are mirrored from RevVault by a publish step, never hand-typed
+- **Rotation**: per-credential-type runbook; rotation updates RevVault first, downstream re-reads from the same source
+
+The Pro-tier commercial offering wraps the RevealUI license: RevealUI Pro unlocks the **RevVault desktop app** + **rotation engine** as Pro features. The CLI and core crate are MIT and free for any tier.
+
+---
+
+## Active Work
+
+### `feat/sync-per-var-path-override` (current branch)
+
+Per-variable vault-path overrides for Vercel sync. Manifest schema gains `[projects.<slug>.vars]` table for case-by-case overrides where the default `[projects.<slug>] vault_prefix` is wrong. Surfacing reference: [`reference_revvault_sync_schema_prefix_with_override.md`](file:///C:/Users/joshu/.claude/projects/--wsl-localhost-ubuntu-home-joshua-v-dev-revfleet/memory/reference_revvault_sync_schema_prefix_with_override.md).
+
+**In scope:** schema parsing, conflict resolution between `vault_prefix` and per-var overrides, sync logic.
+**Out of scope:** UI for editing overrides, rotation hooks for overridden vars (defer to follow-on).
+
+### Recently shipped (last ~30 days, descending)
+
+- `fd306fd` chore(docs): rename `~/suite/` → `~/revfleet/` in CLAUDE.md (#39)
+- `cc43830` fix(core): escape brackets in `update_env_var` doc comment
+- `aa5ebf5` fix(sync): `update_env_var` sends value-only PATCH to preserve type + target
+- `b571920` fix(sync): filter `remote_map` by target to avoid multi-environment ID collision
+- `20d55a3` feat(sync): per-var vault path overrides for Vercel sync (PR open as `feat/sync-per-var-path-override`)
+- `da6ea01` feat(rotation): post-rotate hooks + strict verify + local generator (#37)
+- `9e54c1d` ci: add `tauri-build` workflow for revvault-tauri cross-platform compile validation (#35)
+- `60c2912` chore(ci): SHA-pin all 37 actions in revvault `ci.yml` (#34)
+- `4c7cbe3` feat(cli): add `generate` subcommand for strong passwords (#26)
+
+---
+
+## Roadmap
+
+Pre-1.0 (per [`versioning.md`](https://github.com/RevealUIStudio/revealui-jv/blob/main/.claude/rules/versioning.md)). Promotion to 1.0.0 requires real external consumers + stable contract across one release cycle.
+
+### Phase 0 — Studio internal use (DONE)
+
+CLI feature-complete for daily studio workflow: get/set/list/edit/delete/export-env/search/generate; age encryption; namespaces; fuzzy search; path validation.
+
+### Phase 1 — Vercel sync (IN FLIGHT)
+
+Per-var vault-path overrides; multi-environment target filtering; post-rotate hooks. Surface: `revvault sync vercel` against a `[projects.<slug>]` manifest.
+
+**Owner action items:** none currently — agent-driven.
+
+### Phase 2 — Public Tauri release (NOT STARTED)
+
+Signed + notarized desktop binary for macOS/Windows; auto-update pipeline; public download page (likely on `revealui.com/revvault` or a dedicated subdomain).
+
+**Owner action items:** Apple notarization cert; Windows code-signing cert; auto-update server hosting decision.
+
+### Phase 3 — Audit log + drift detection (NOT STARTED)
+
+`revvault audit log` for `get`/`set` history; `revvault status` cross-check against RevealUI's `.env.example` to surface drift between expected and stored secrets.
+
+### Phase 4 — Multi-identity / team vaults (NOT STARTED)
+
+Multi-identity vault model (single age recipient list per vault, multiple consumers). Defers to a future "team plan" of RevealUI Pro.
+
+---
+
+## Owner Action Queue
+
+| Item | Unblocks |
+|---|---|
+| Decide Tauri public-release distribution channel (revealui.com subpath vs separate domain vs GitHub releases only) | Phase 2 |
+| Procure Apple notarization + Windows code-signing certs | Phase 2 |
+
+---
+
+## See also
+
+- [`docs/MASTER_SPEC.md`](./MASTER_SPEC.md) — surface area + architecture
+- [`README.md`](../README.md) — quick start + CLI command reference
+- [`revealui-jv:docs/MASTER_INDEX.md`](https://github.com/RevealUIStudio/revealui-jv/blob/main/docs/MASTER_INDEX.md) — fleet-level navigation
+- [`revealui:.claude/rules/secrets.md`](https://github.com/RevealUIStudio/revealui/blob/main/.claude/rules/secrets.md) — fleet-wide secrets convention (RevVault as source of truth)

--- a/docs/MASTER_SPEC.md
+++ b/docs/MASTER_SPEC.md
@@ -1,0 +1,211 @@
+# RevVault — Master Spec
+
+**Last Updated:** 2026-05-10
+**Status:** Pre-1.0 — production-grade for studio internal use; surface area stable
+**Repo:** [RevealUIStudio/revvault](https://github.com/RevealUIStudio/revvault)
+
+> Surface area, architecture, contracts. Companion to [`MASTER_PLAN.md`](./MASTER_PLAN.md) (status + roadmap).
+
+---
+
+## Mission
+
+Age-encrypted secret vault for RevFleet. Source of truth for every secret per the fleet-wide secrets rule. CLI + Tauri 2 desktop app. 100% [passage](https://github.com/FiloSottile/passage)-compatible.
+
+The trust story compresses to one sentence: *Secrets live in RevVault, encrypted by an age identity that doesn't leave the developer's machine.*
+
+---
+
+## Repository structure
+
+```
+revvault/
+├── Cargo.toml                # workspace root
+├── crates/
+│   ├── core/                 # vault primitives — age encryption, path validation, namespace logic
+│   ├── cli/                  # binary `revvault` — get/set/list/search/delete/edit/export-env/generate/sync
+│   └── tauri-app/            # Tauri 2 backend (Rust commands) for the desktop UI
+├── frontend/                 # React 19 desktop UI (consumes tauri-app commands)
+├── scripts/                  # support scripts (test fixtures, dev helpers)
+├── flake.nix                 # Nix dev shell
+├── rust-toolchain.toml       # pinned Rust version
+└── deny.toml                 # cargo-deny rules
+```
+
+### Crate boundaries
+
+| Crate | Responsibility | Dependencies |
+|---|---|---|
+| `core` | age encryption/decryption, path validation, namespace parsing, vault traversal, manifest parsing | `age`, `serde`, `toml` |
+| `cli` | argv parsing, command dispatch, terminal IO (clipboard, prompts), shell-friendly output | `core`, `clap`, `dialoguer` |
+| `tauri-app` | Tauri command handlers wrapping `core` for the desktop UI | `core`, `tauri` |
+
+The frontend never touches `core` directly — it goes through `tauri-app` IPC. This boundary keeps secret handling in Rust and out of the JS heap.
+
+---
+
+## CLI surface
+
+| Command | Purpose | Example |
+|---|---|---|
+| `revvault get <path>` | Decrypt + print one secret to stdout (or clipboard via `--clip`) | `revvault get credentials/stripe/secret-key` |
+| `revvault get --json <path>` | JSON output (path + value) — use this in non-TTY contexts; bare `get` returns empty in `$()` (per memory `feedback_revvault_get_silent_in_subshell`) | `revvault --json get credentials/stripe/secret-key \| jq -r .value` |
+| `revvault set <path>` | Encrypt + store from stdin or interactive prompt | `echo "sk_live_..." \| revvault set credentials/stripe/secret-key` |
+| `revvault list [<prefix>]` | List secret paths, optionally namespace-filtered | `revvault list credentials/` |
+| `revvault search <query>` | Fuzzy search across paths | `revvault search stripe` |
+| `revvault delete <path>` | Remove a secret | `revvault delete credentials/old-key` |
+| `revvault edit <path>` | Decrypt → open in `$EDITOR` → re-encrypt on save | `revvault edit credentials/stripe/secret-key` |
+| `revvault export-env [<prefix>]` | Materialize `.env`-shaped output for direnv | `revvault export-env revealui/dev/ > .envrc.secret` |
+| `revvault generate` | Generate a strong password (CSPRNG) | `revvault generate \| revvault set credentials/new` |
+| `revvault sync vercel <project>` | Sync a manifest-defined slice of vault to Vercel project env vars | `revvault sync vercel revealui-prod` |
+| `revvault sync vercel --dry-run <project>` | Show diff without writing | `revvault sync vercel --dry-run revealui-prod` |
+
+### Path conventions
+
+Paths are lower-kebab, grouped by repo/product, then subsystem:
+
+```
+<project>/<subsystem>/<name>
+```
+
+Examples:
+
+```
+revealui/dev/electric/service-url
+revealui/dev/electric/secret
+revealui/prod/neon/postgres-url
+revealui/prod/stripe/secret-key
+revealui/prod/stripe/webhook-secret
+revealcoin/mint-authority.json
+revdev/license-signing-key
+credentials/github/<account>
+credentials/anthropic/<account>
+ssh/<host>/<key-name>
+```
+
+The first path segment is the **namespace**; commands accept namespace prefixes for `list`/`export-env`/`sync`.
+
+---
+
+## Storage layout
+
+```
+$HOME/.revealui/passage-store/             # default vault root
+├── revealui/
+│   ├── dev/
+│   │   ├── electric/
+│   │   │   ├── service-url.age
+│   │   │   └── secret.age
+│   │   └── admin-session-cookie.age
+│   └── prod/...
+├── revealcoin/
+│   └── mint-authority.json.age
+├── credentials/
+│   └── github/joshua.age
+└── ...
+```
+
+Each `.age` file is the encrypted secret. Filenames preserve the secret's logical extension (`.json`, `.pem`, etc.) ahead of `.age`.
+
+### Identity
+
+The age identity is read from `~/.age-identity/keys.txt` by default (override via `--identity <path>`). This file should never leave the developer's machine — that's the encryption boundary.
+
+---
+
+## Tauri desktop UI
+
+Built on Tauri 2 + React 19. Surface mirrors the CLI plus richer browse/search:
+
+| UI surface | Backed by |
+|---|---|
+| Search bar (fuzzy) | `core::search` via `tauri-app::search_secrets` |
+| Tree browser (namespaces) | `core::list` via `tauri-app::list_secrets` |
+| Detail pane (reveal/copy/delete/edit) | `core::{get,set,delete}` via tauri commands |
+| Add new secret | `core::set` via `tauri-app::create_secret` |
+| Import flow | `core::import` (categorizes by path heuristic) |
+
+The desktop app is currently used internally; public release is **Phase 2** in `MASTER_PLAN.md` (notarization + auto-update pipeline pending).
+
+---
+
+## Sync surface
+
+### Vercel sync manifest
+
+Per [`reference_revvault_sync_schema_prefix_with_override`](file:///C:/Users/joshu/.claude/projects/--wsl-localhost-ubuntu-home-joshua-v-dev-revfleet/memory/reference_revvault_sync_schema_prefix_with_override.md):
+
+```toml
+# revvault-sync.toml
+[projects.revealui-prod]
+vercel_project = "revealui-prod"
+vault_prefix = "revealui/prod/"   # secrets under this prefix sync as-is
+target = "production"             # vercel env target
+
+# per-var overrides (lands via #PR feat/sync-per-var-path-override)
+[projects.revealui-prod.vars]
+DATABASE_URL = { vault_path = "revealui/prod/neon/postgres-url" }
+STRIPE_SECRET_KEY = { vault_path = "revealui/prod/stripe/secret-key" }
+```
+
+The default behavior maps every `<vault_prefix>/<name>` to env var `NAME` in the target environment. The per-var `[vars]` table overrides individual mappings when default prefix-based naming is wrong.
+
+### Sync semantics
+
+- `value-only PATCH` to Vercel API to preserve env-var type + target on update (`aa5ebf5`)
+- `remote_map` filtered by `target` to avoid multi-environment ID collision (`b571920`)
+- Manifest schema enforced via `serde` deserialization
+- Dry-run prints unified diff between vault state and remote state
+
+---
+
+## Rotation surface
+
+Per `da6ea01` (#37):
+
+- Rotation hooks: `[rotation.<name>]` blocks in manifest define `pre-rotate` + `post-rotate` shell hooks
+- Strict verify: every rotation re-fetches the new value to confirm encryption + retrieval round-trip
+- Local generator: `revvault generate --shape <type>` produces shape-aware values (URL-safe random, alnum, digits-only, etc.)
+
+Per-credential-type rotation runbook lives at [`revealui:docs/CREDENTIAL-ROTATION-RUNBOOK`](https://github.com/RevealUIStudio/revealui/blob/main/docs/CREDENTIAL-ROTATION-RUNBOOK).
+
+---
+
+## Security posture
+
+- **Encryption boundary:** the age identity at `~/.age-identity/keys.txt`. Never copied to remote, never embedded in CI secrets, never logged.
+- **Path validation:** directory traversal (`..`), null bytes, shell metacharacters rejected at the API layer in `core::path::validate`.
+- **No plaintext on disk** outside a tmpfs-backed restore directory zeroized on command exit.
+- **No logging of values** — debug logs reference paths, never decrypted bodies.
+- **CI:** SHA-pinned 37 actions (`60c2912`); Tauri cross-platform build workflow (`9e54c1d`); cargo-deny (`deny.toml`); rust-toolchain pinned (`rust-toolchain.toml`); `gitleaks` scanned.
+
+---
+
+## Versioning
+
+Pre-1.0 per [`versioning.md`](https://github.com/RevealUIStudio/revealui-jv/blob/main/.claude/rules/versioning.md). Cargo workspace crates use independent SemVer. Promotion to 1.0.0 gated on real external consumers + stable contract across at least one release cycle.
+
+---
+
+## Compose / coexistence
+
+| Other product | Relationship |
+|---|---|
+| **RevealUI** | Consumer — every secret in RevealUI's `.env`/CI/runbook lives in RevVault per `secrets.md` rule |
+| **RevealCoin** | Consumer — keypair files (`revealcoin/mint-authority.json`, etc.) stored as `.age` files |
+| **RevDev** | Consumer — license signing keys |
+| **RevForge** | Consumer — per-customer secrets at `forge/customers/<slug>/*` paths in vault |
+| **RevKit** | Sets up the age-identity mount path RevVault expects (`~/.age-identity/keys.txt`) |
+| **RevCon** | Independent — RevCon manages editor configs, doesn't touch secrets |
+| **RevSkills** | Independent |
+
+No reverse dependency: RevVault has no awareness of consumer products. The contract is the encrypted-file-on-disk format + the CLI surface.
+
+---
+
+## See also
+
+- [`docs/MASTER_PLAN.md`](./MASTER_PLAN.md) — current status, phases, owner actions
+- [`README.md`](../README.md) — quick start + setup
+- [`revealui-jv:docs/MASTER_INDEX.md`](https://github.com/RevealUIStudio/revealui-jv/blob/main/docs/MASTER_INDEX.md) — fleet-level navigation
+- [`revealui:.claude/rules/secrets.md`](https://github.com/RevealUIStudio/revealui/blob/main/.claude/rules/secrets.md) — fleet-wide RevVault-first secrets rule

--- a/docs/MASTER_SPEC.md
+++ b/docs/MASTER_SPEC.md
@@ -57,8 +57,10 @@ The frontend never touches `core` directly — it goes through `tauri-app` IPC. 
 | `revvault edit <path>` | Decrypt → open in `$EDITOR` → re-encrypt on save | `revvault edit credentials/stripe/secret-key` |
 | `revvault export-env [<prefix>]` | Materialize `.env`-shaped output for direnv | `revvault export-env revealui/dev/ > .envrc.secret` |
 | `revvault generate` | Generate a strong password (CSPRNG) | `revvault generate \| revvault set credentials/new` |
-| `revvault sync vercel <project>` | Sync a manifest-defined slice of vault to Vercel project env vars | `revvault sync vercel revealui-prod` |
-| `revvault sync vercel --dry-run <project>` | Show diff without writing | `revvault sync vercel --dry-run revealui-prod` |
+| `revvault sync vercel [--manifest <path>]` | Show diff between vault + Vercel env vars (default = dry-run; manifest defaults to `revvault-vercel.toml`) | `revvault sync vercel --manifest revvault-vercel.toml` |
+| `revvault sync vercel --apply [--manifest <path>]` | Actually write the diff to Vercel | `revvault sync vercel --apply` |
+| `revvault sync vercel --pull [--manifest <path>]` | Import existing Vercel vars into the vault | `revvault sync vercel --pull` |
+| `revvault sync vercel --token <token> ...` | Override Vercel API token (or set `VERCEL_TOKEN` env var) | `revvault sync vercel --apply --token $VERCEL_TOKEN` |
 
 ### Path conventions
 
@@ -136,19 +138,23 @@ The desktop app is currently used internally; public release is **Phase 2** in `
 Per [`reference_revvault_sync_schema_prefix_with_override`](file:///C:/Users/joshu/.claude/projects/--wsl-localhost-ubuntu-home-joshua-v-dev-revfleet/memory/reference_revvault_sync_schema_prefix_with_override.md):
 
 ```toml
-# revvault-sync.toml
-[projects.revealui-prod]
-vercel_project = "revealui-prod"
-vault_prefix = "revealui/prod/"   # secrets under this prefix sync as-is
-target = "production"             # vercel env target
+# revvault-vercel.toml — schema per crates/cli/src/commands/sync.rs ProjectSync
+team_id = "team_abc123"  # optional; for personal accounts omit
 
-# per-var overrides (lands via #PR feat/sync-per-var-path-override)
+[projects.revealui-prod]
+project_id = "prj_xyz789"          # Vercel project ID (required)
+vault_prefix = "revealui/prod/"    # secrets under this prefix sync as-is (required)
+targets = ["production"]           # env targets list (default: ["production", "preview", "development"])
+skip = ["VERCEL_AUTOMATION_TOKEN"] # var names to skip (integration-managed, etc.)
+
+# per-var overrides — feature shipped via feat/sync-per-var-path-override
+# Maps a Vercel var name to an absolute vault path; bypasses <vault_prefix>/<NAME> default
 [projects.revealui-prod.vars]
-DATABASE_URL = { vault_path = "revealui/prod/neon/postgres-url" }
-STRIPE_SECRET_KEY = { vault_path = "revealui/prod/stripe/secret-key" }
+DATABASE_URL = "revealui/prod/neon/postgres-url"
+STRIPE_SECRET_KEY = "revealui/prod/stripe/secret-key"
 ```
 
-The default behavior maps every `<vault_prefix>/<name>` to env var `NAME` in the target environment. The per-var `[vars]` table overrides individual mappings when default prefix-based naming is wrong.
+The default behavior maps every `<vault_prefix>/<name>` to env var `NAME` for each target in `targets`. The per-var `[projects.<slug>.vars]` table maps a Vercel var name to a literal vault path, overriding the default prefix-based naming.
 
 ### Sync semantics
 


### PR DESCRIPTION
## Summary

Adds product-scoped `docs/MASTER_PLAN.md` + `docs/MASTER_SPEC.md` as part of the fleet master-of-masters scaffold.

- `docs/MASTER_PLAN.md` — current status, active phases, owner action queue
- `docs/MASTER_SPEC.md` — surface area, architecture, contracts, repository structure

Doc-only commit. No code touched, no edits to existing files (additive only).

## Why

Audit-first SDLC pass surfaced that this product had no master-level plan or spec doc. Adding them gives any agent or human contributor a single place to land for "what does this product do, what's the active state, what's the surface area." Companion files were added to every other product in the fleet in the same scaffolding pass.

## Test plan

- [ ] CI green
- [ ] `docs/MASTER_PLAN.md` and `docs/MASTER_SPEC.md` render on GitHub with intact internal links
- [ ] No files outside `docs/` modified
