### PR TITLE
chore(docs): add YAML frontmatter to MASTER_PLAN + MASTER_SPEC

### DIFF
--- a/docs/MASTER_PLAN.md
+++ b/docs/MASTER_PLAN.md
@@ -1,3 +1,11 @@
+---
+type: master-plan
+repo: revvault
+last-updated: 2026-05-10
+owner: RevealUI Studio
+staleness-status: FRESH
+---
+
 # RevVault — Master Plan
 
 **Last Updated:** 2026-05-10

--- a/docs/MASTER_SPEC.md
+++ b/docs/MASTER_SPEC.md
@@ -1,3 +1,11 @@
+---
+type: master-spec
+repo: revvault
+last-updated: 2026-05-10
+owner: RevealUI Studio
+staleness-status: FRESH
+---
+
 # RevVault — Master Spec
 
 **Last Updated:** 2026-05-10


### PR DESCRIPTION
## Summary
Adds uniform YAML frontmatter to `docs/MASTER_PLAN.md` + `docs/MASTER_SPEC.md` per the master-doc pattern audit (an internal repo:docs/audits/2026-05-11-master-doc-pattern-audit.md`).

Schema: `type`, `repo`, `last-updated`, `owner`, `staleness-status`. Body content unchanged.

## Why
Audit identified that 16 of 18 MASTER_*.md files across the fleet lacked YAML frontmatter. This is GAP-195 in an internal repo (closed alongside). After this lands, the fleet has uniform frontmatter, enabling glob-discoverable fleet-level staleness checks (future GAP-198: SessionStart hook).

## Test plan
- [ ] CI passes (docs-only change; no behavior impact)
- [ ] `head -1 docs/MASTER_PLAN.md` returns `---`
- [ ] `head -1 docs/MASTER_SPEC.md` returns `---`
