### PR TITLE
revvault 0.2.0: durable sync redesign (remove --pull + doctor)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,22 @@
+# Gitleaks configuration for revvault.
+#
+# Extends the upstream default ruleset and adds one narrow allowlist.
+title = "revvault gitleaks config"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = """
+crates/core/src/sync/shape.rs is the outbound-sync value-shape classifier.
+By design it contains secret-SHAPED test fixtures — fake PEM blocks, fake
+Stripe-key prefixes, fake hex strings — that exercise the shape predicates
+(empty / null / ciphertext-envelope / postgres-url / stripe-key / pem / hex /
+…). It holds no real secrets: the non-test code is pure prefix / length /
+char-class predicates with no literal values, and the #[cfg(test)] fixtures
+are deliberately well-known dummy strings. Allowlisting this one file keeps
+the gitleaks gate honest everywhere else.
+"""
+paths = [
+  '''crates/core/src/sync/shape\.rs''',
+]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,83 @@
+# Changelog
+
+All notable changes to revvault are documented here. Follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) conventions; versions follow [SemVer 2.0.0](https://semver.org/).
+
+## [0.2.0] — 2026-05-14
+
+### Breaking changes
+
+- **`--pull` removed from `revvault sync vercel`** (closes incident-2026-05-11). The
+  inverted-direction primitive (Vercel → vault) is gone. `revvault` is the
+  canonical age-encrypted store; Vercel is a downstream copy. Any invocation
+  that passed `--pull` will now error with a migration message pointing at
+  `docs/bootstrap-from-vercel.md`. See the spec at
+  `docs/specs/revvault-sync-durable-redesign.md` for the full rationale.
+
+### Added
+
+- **`revvault doctor [--manifest <path>] [--json]`** — vault-only health check.
+  Reads every var declared in a sync manifest, fetches the vault value, and
+  validates it against the declared shape. Never touches Vercel. Exit code `0`
+  when all entries pass; `1` when any entry fails or is missing. Use before any
+  push, after any vault mutation (set / edit / rotate / migrate / restore).
+
+- **`crates/core/src/sync/shape.rs`** — new shape-validation module. Provides
+  `Shape` (13 variants: `any`, `postgres-url`, `https-url`, `stripe-key`,
+  `stripe-key-live-only`, `stripe-webhook`, `stripe-resource`, `pem-private-key`,
+  `pem-public-key`, `hex32`, `hex64`, `email`, `flag`), `ShapeViolation`, and
+  `check`/`classify` functions. All checks are prefix-match + length +
+  character-class predicates — no regex.
+
+- **Shape validation on push** — `revvault sync vercel --apply` now validates
+  every vault value against its declared shape before calling the Vercel API.
+  Values that fail the check (empty, null-literal, Vercel v2 envelope, or
+  declared-shape mismatch) are logged as `drop-shape` audit entries and skipped;
+  the push continues for the remaining entries.
+
+- **Shape validation in rotation sync hook** — `push_to_vercel` in
+  `crates/core/src/rotation/sync_hook.rs` applies the same universal structural
+  checks (empty / null / envelope) to the fresh rotation outcome before making
+  any Vercel API call. A misbehaving rotation provider (e.g., one that returns
+  an empty body) can no longer poison Vercel.
+
+- **Rotation provider `output_shape`** — optional field on
+  `[providers.<name>]` in `rotation.toml`. When declared, the executor validates
+  the fresh rotation outcome against the shape **before** writing to the vault.
+  A mismatch aborts the rotation and leaves the old key in place.
+
+- **MATCH skip on push** — `revvault sync vercel --apply` now attempts to fetch
+  decrypted remote values via `decrypt=true` (requires `env:read:decrypted` scope
+  on the Vercel token). When vault and Vercel values match, the API call is
+  skipped and a `match` audit entry is recorded. Falls back gracefully to
+  assume-drift (current behavior) when the token lacks the scope (403).
+
+- **`value_shape` in audit log** — every audit entry now includes a
+  `value_shape` field (e.g., `"postgres-url"`, `"stripe-key"`, `"empty"`,
+  `"vercel-envelope"`) so log review surfaces corruption without needing to
+  re-read the vault. Applies to both the sync audit log and the rotation sync
+  hook's `SyncLogEntry`.
+
+- **Manifest per-var shape declarations** — `[projects.<slug>.vars]` now
+  accepts an inline-table form:
+  ```toml
+  POSTGRES_URL = { path = "revealui/prod/db/postgres-url", shape = "postgres-url" }
+  ```
+  Bare-string entries (`POSTGRES_URL = "revealui/prod/db/postgres-url"`) continue
+  to work unchanged (shape defaults to `any`). Existing manifests require no
+  changes.
+
+- **`list_env_vars_with_values`** on `VercelClient` — fetches env vars with
+  `decrypt=true` for MATCH detection. Returns `Ok(None)` on 403 (scope missing)
+  so callers can fall back safely.
+
+### Removed
+
+- `pull_mode` function in `crates/cli/src/commands/sync.rs`
+- `detect_path_collisions` function (was only used to gate pull)
+- `pull: bool` field from `SyncArgs`
+
+## [0.1.0] — initial release
+
+First working version. Age-encrypted vault, CLI, Tauri desktop app, rotation
+providers, and the bidirectional `sync vercel` command (now superseded in 0.2.0
+by the push-only redesign).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4432,7 +4432,7 @@ dependencies = [
 
 [[package]]
 name = "revvault-cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "age",
  "anyhow",
@@ -4464,7 +4464,7 @@ dependencies = [
 
 [[package]]
 name = "revvault-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "age",
  "anyhow",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "revvault-tauri"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,14 +3,14 @@ resolver = "2"
 members = ["crates/core", "crates/cli", "crates/tauri-app"]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT"
 authors = ["Joshua Vaughn <joshua.v.dev@gmail.com>"]
 
 [workspace.dependencies]
-revvault-core = { version = "0.1", path = "crates/core" }
+revvault-core = { version = "0.2", path = "crates/core" }
 age = { version = "0.11", features = ["armor"] }
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }

--- a/crates/cli/src/commands/doctor.rs
+++ b/crates/cli/src/commands/doctor.rs
@@ -304,7 +304,7 @@ mod tests {
         let manifest_content = std::fs::read_to_string(&manifest).unwrap();
         let manifest_parsed: SyncManifest = toml::from_str(&manifest_content).unwrap();
 
-        for (_project, project_cfg) in &manifest_parsed.projects {
+        for project_cfg in manifest_parsed.projects.values() {
             for (var_name, entry) in &project_cfg.vars {
                 let secret = store.get(entry.path()).unwrap();
                 let raw = {
@@ -344,8 +344,8 @@ mod tests {
         let manifest_parsed: SyncManifest = toml::from_str(&manifest_content).unwrap();
 
         let mut found_failure = false;
-        for (_project, project_cfg) in &manifest_parsed.projects {
-            for (_, entry) in &project_cfg.vars {
+        for project_cfg in manifest_parsed.projects.values() {
+            for entry in project_cfg.vars.values() {
                 let secret = store.get(entry.path()).unwrap();
                 let raw = {
                     use secrecy::ExposeSecret;

--- a/crates/cli/src/commands/doctor.rs
+++ b/crates/cli/src/commands/doctor.rs
@@ -1,0 +1,399 @@
+//! `revvault doctor` — vault-only health check.
+//!
+//! Reads every var declared in the sync manifest, fetches its value from the
+//! vault, and validates the shape. Never touches any external system. Never
+//! mutates the vault.
+//!
+//! Exit codes:
+//! - `0` — all entries pass
+//! - `1` — one or more entries failed shape validation or could not be read
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+
+use anyhow::Context;
+use clap::Args;
+use serde::Serialize;
+
+use revvault_core::sync::shape::{self, Shape};
+use revvault_core::{Config, PassageStore};
+
+// ── CLI args ────────────────────────────────────────────────────────────────
+
+#[derive(Args)]
+pub struct DoctorArgs {
+    /// Path to the sync manifest (default: revvault-vercel.toml in CWD)
+    #[arg(long, default_value = "revvault-vercel.toml")]
+    pub manifest: PathBuf,
+
+    /// Output structured JSON
+    #[arg(long)]
+    pub json: bool,
+}
+
+// ── Manifest schema (subset — only what doctor needs) ───────────────────────
+
+#[derive(Debug, serde::Deserialize)]
+struct SyncManifest {
+    #[serde(default)]
+    projects: HashMap<String, ProjectSync>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct ProjectSync {
+    vault_prefix: String,
+    #[serde(default)]
+    vars: HashMap<String, VarEntry>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(untagged)]
+enum VarEntry {
+    Path(String),
+    Object { path: String, shape: Shape },
+}
+
+impl VarEntry {
+    fn path(&self) -> &str {
+        match self {
+            Self::Path(p) => p,
+            Self::Object { path, .. } => path,
+        }
+    }
+
+    fn shape(&self) -> Shape {
+        match self {
+            Self::Path(_) => Shape::Any,
+            Self::Object { shape, .. } => *shape,
+        }
+    }
+}
+
+// ── Output types ─────────────────────────────────────────────────────────────
+
+#[derive(Debug, Serialize)]
+pub struct DoctorEntry {
+    pub path: String,
+    pub var_name: String,
+    pub project: String,
+    /// "postgres-url" / "stripe-key" / "empty" / "unknown" / etc.
+    pub actual_shape: String,
+    /// Declared shape name from manifest, or "any" if not declared.
+    pub expected_shape: String,
+    /// "pass" | "fail" | "missing"
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct DoctorReport {
+    entries: Vec<DoctorEntry>,
+    total: usize,
+    passed: usize,
+    failed: usize,
+}
+
+// ── Runner ───────────────────────────────────────────────────────────────────
+
+pub fn run(args: DoctorArgs) -> anyhow::Result<()> {
+    let manifest_content = fs::read_to_string(&args.manifest)
+        .with_context(|| format!("Cannot read manifest: {}", args.manifest.display()))?;
+    let manifest: SyncManifest =
+        toml::from_str(&manifest_content).context("Invalid manifest TOML")?;
+
+    let config = Config::resolve()?;
+    let store = PassageStore::open(config)?;
+
+    let mut entries: Vec<DoctorEntry> = Vec::new();
+
+    for (project_name, project_cfg) in &manifest.projects {
+        // Collect all var names: explicit overrides + everything under the prefix.
+        let mut var_pairs: Vec<(String, String, Shape)> = Vec::new();
+
+        for (var_name, entry) in &project_cfg.vars {
+            var_pairs.push((var_name.clone(), entry.path().to_string(), entry.shape()));
+        }
+
+        // Discover additional paths from the vault under the prefix.
+        let prefix_secrets = store
+            .list(Some(&project_cfg.vault_prefix))
+            .unwrap_or_default();
+        for secret_entry in &prefix_secrets {
+            let var_name = secret_entry
+                .path
+                .strip_prefix(&format!("{}/", project_cfg.vault_prefix))
+                .unwrap_or(&secret_entry.path)
+                .to_string();
+            if !project_cfg.vars.contains_key(&var_name) {
+                var_pairs.push((var_name, secret_entry.path.clone(), Shape::Any));
+            }
+        }
+
+        for (var_name, vault_path, declared_shape) in var_pairs {
+            let entry = match store.get(&vault_path) {
+                Err(e) => DoctorEntry {
+                    path: vault_path.clone(),
+                    var_name: var_name.clone(),
+                    project: project_name.clone(),
+                    actual_shape: "missing".into(),
+                    expected_shape: shape_name(declared_shape),
+                    status: "missing".into(),
+                    error: Some(format!("{e}")),
+                },
+                Ok(secret) => {
+                    let raw = secret.expose_secret_str();
+                    let actual = shape::classify(raw);
+                    match shape::check(raw, declared_shape) {
+                        Ok(()) => DoctorEntry {
+                            path: vault_path.clone(),
+                            var_name: var_name.clone(),
+                            project: project_name.clone(),
+                            actual_shape: actual,
+                            expected_shape: shape_name(declared_shape),
+                            status: "pass".into(),
+                            error: None,
+                        },
+                        Err(violation) => DoctorEntry {
+                            path: vault_path.clone(),
+                            var_name: var_name.clone(),
+                            project: project_name.clone(),
+                            actual_shape: actual,
+                            expected_shape: shape_name(declared_shape),
+                            status: "fail".into(),
+                            error: Some(violation.to_string()),
+                        },
+                    }
+                }
+            };
+            entries.push(entry);
+        }
+    }
+
+    // Sort for stable output (project + path).
+    entries.sort_by(|a, b| a.project.cmp(&b.project).then(a.path.cmp(&b.path)));
+
+    let total = entries.len();
+    let failed = entries.iter().filter(|e| e.status != "pass").count();
+    let passed = total - failed;
+
+    if args.json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&DoctorReport {
+                entries,
+                total,
+                passed,
+                failed,
+            })?
+        );
+    } else {
+        for entry in &entries {
+            let (symbol, color) = match entry.status.as_str() {
+                "pass" => ("✓", "\x1b[32m"),
+                "fail" => ("✗", "\x1b[31m"),
+                _ => ("?", "\x1b[33m"),
+            };
+            let detail = match entry.status.as_str() {
+                "pass" => format!("{} ({})", entry.path, entry.actual_shape),
+                _ => format!(
+                    "{} — {}",
+                    entry.path,
+                    entry.error.as_deref().unwrap_or("unknown error")
+                ),
+            };
+            println!("  {color}{symbol}\x1b[0m {}", detail);
+        }
+        println!();
+        if failed == 0 {
+            println!("\x1b[32mAll {} entries pass.\x1b[0m", total);
+        } else {
+            println!("\x1b[31m{} of {} entries failed.\x1b[0m", failed, total);
+        }
+    }
+
+    if failed > 0 {
+        std::process::exit(1);
+    }
+
+    Ok(())
+}
+
+fn shape_name(shape: Shape) -> String {
+    serde_json::to_value(shape)
+        .ok()
+        .and_then(|v| v.as_str().map(|s| s.to_string()))
+        .unwrap_or_else(|| format!("{shape:?}"))
+}
+
+// Helper trait to expose &str from SecretString without leaking to logs.
+trait ExposeSecretStr {
+    fn expose_secret_str(&self) -> &str;
+}
+
+impl ExposeSecretStr for secrecy::SecretString {
+    fn expose_secret_str(&self) -> &str {
+        use secrecy::ExposeSecret;
+        self.expose_secret()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn setup_temp_store() -> (tempfile::TempDir, PassageStore) {
+        let dir = tempfile::tempdir().unwrap();
+        let store_dir = dir.path().join("store");
+        std::fs::create_dir_all(&store_dir).unwrap();
+
+        let id = age::x25519::Identity::generate();
+        let recipient = id.to_public();
+
+        let id_file = dir.path().join("keys.txt");
+        std::fs::write(
+            &id_file,
+            format!(
+                "# test key\n{}\n",
+                secrecy::ExposeSecret::expose_secret(&id.to_string())
+            ),
+        )
+        .unwrap();
+
+        let recip_file = store_dir.join(".age-recipients");
+        std::fs::write(&recip_file, format!("{}\n", recipient)).unwrap();
+
+        let config = revvault_core::Config {
+            store_dir,
+            identity_file: id_file,
+            recipients_file: recip_file,
+            editor: None,
+            tmpdir: None,
+        };
+        let store = PassageStore::open(config).unwrap();
+        (dir, store)
+    }
+
+    fn write_manifest(dir: &tempfile::TempDir, content: &str) -> PathBuf {
+        let path = dir.path().join("revvault-vercel.toml");
+        std::fs::write(&path, content).unwrap();
+        path
+    }
+
+    #[test]
+    fn doctor_passes_when_vault_matches_manifest_shapes() {
+        let (dir, store) = setup_temp_store();
+        store
+            .upsert("revealui/prod/db/postgres-url", b"postgresql://host/db")
+            .unwrap();
+
+        let manifest = write_manifest(
+            &dir,
+            r#"
+            [projects.api]
+            project_id = "prj_test"
+            vault_prefix = "revealui/prod"
+
+            [projects.api.vars]
+            POSTGRES_URL = { path = "revealui/prod/db/postgres-url", shape = "postgres-url" }
+            "#,
+        );
+
+        // Build entries directly to test the logic without spawning a process.
+        let manifest_content = std::fs::read_to_string(&manifest).unwrap();
+        let manifest_parsed: SyncManifest = toml::from_str(&manifest_content).unwrap();
+
+        for (_project, project_cfg) in &manifest_parsed.projects {
+            for (var_name, entry) in &project_cfg.vars {
+                let secret = store.get(entry.path()).unwrap();
+                let raw = {
+                    use secrecy::ExposeSecret;
+                    secret.expose_secret().to_string()
+                };
+                let result = shape::check(&raw, entry.shape());
+                assert!(result.is_ok(), "expected pass for {var_name}: {result:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn doctor_fails_when_any_entry_is_corrupted() {
+        let (dir, store) = setup_temp_store();
+        // Write a Vercel envelope (the 2026-05-09 incident corruption).
+        store
+            .upsert(
+                "revealui/prod/db/postgres-url",
+                b"eyJ2IjoidjIiLCJlcGsiOnsieCI6InRlc3QifX0=",
+            )
+            .unwrap();
+
+        let manifest = write_manifest(
+            &dir,
+            r#"
+            [projects.api]
+            project_id = "prj_test"
+            vault_prefix = "revealui/prod"
+
+            [projects.api.vars]
+            POSTGRES_URL = { path = "revealui/prod/db/postgres-url", shape = "postgres-url" }
+            "#,
+        );
+
+        let manifest_content = std::fs::read_to_string(&manifest).unwrap();
+        let manifest_parsed: SyncManifest = toml::from_str(&manifest_content).unwrap();
+
+        let mut found_failure = false;
+        for (_project, project_cfg) in &manifest_parsed.projects {
+            for (_, entry) in &project_cfg.vars {
+                let secret = store.get(entry.path()).unwrap();
+                let raw = {
+                    use secrecy::ExposeSecret;
+                    secret.expose_secret().to_string()
+                };
+                if shape::check(&raw, entry.shape()).is_err() {
+                    found_failure = true;
+                }
+            }
+        }
+        assert!(
+            found_failure,
+            "expected at least one failure for corrupted entry"
+        );
+    }
+
+    #[test]
+    fn doctor_json_output_stable() {
+        let entry = DoctorEntry {
+            path: "revealui/prod/db/postgres-url".into(),
+            var_name: "POSTGRES_URL".into(),
+            project: "api".into(),
+            actual_shape: "postgres-url".into(),
+            expected_shape: "postgres-url".into(),
+            status: "pass".into(),
+            error: None,
+        };
+        let json = serde_json::to_string(&entry).unwrap();
+        assert!(json.contains(r#""path":"revealui/prod/db/postgres-url""#));
+        assert!(json.contains(r#""status":"pass""#));
+        assert!(json.contains(r#""actual_shape":"postgres-url""#));
+        assert!(!json.contains("error"));
+
+        let report = DoctorReport {
+            entries: vec![entry],
+            total: 1,
+            passed: 1,
+            failed: 0,
+        };
+        let report_json = serde_json::to_string_pretty(&report).unwrap();
+        assert!(report_json.contains("\"entries\""));
+        assert!(report_json.contains("\"total\": 1"));
+    }
+
+    #[test]
+    fn shape_name_serializes_correctly() {
+        assert_eq!(shape_name(Shape::PostgresUrl), "postgres-url");
+        assert_eq!(shape_name(Shape::StripeKeyLiveOnly), "stripe-key-live-only");
+        assert_eq!(shape_name(Shape::Any), "any");
+    }
+}

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod completions;
 pub mod delete;
+pub mod doctor;
 pub mod edit;
 pub mod export_env;
 pub mod generate;

--- a/crates/cli/src/commands/sync.rs
+++ b/crates/cli/src/commands/sync.rs
@@ -217,12 +217,19 @@ async fn push_mode(
         // Attempt to fetch decrypted values for MATCH detection. Falls back
         // to None when the token lacks `env:read:decrypted` scope (403),
         // which causes all existing vars to be treated as needing an update.
+        //
+        // Filter by the configured targets before collapsing by key — same
+        // as `remote_map` below. Without this, a row for a non-synced target
+        // (e.g. preview) could win the per-key collapse and a stale value on
+        // our actual target (e.g. production) would be falsely classified as
+        // a MATCH and skipped, leaving the synced target outdated.
         let remote_decrypted_map: Option<HashMap<String, String>> = match client
             .list_env_vars_with_values(&project_cfg.project_id)
             .await
         {
             Ok(Some(vars)) => Some(
                 vars.into_iter()
+                    .filter(|v| project_cfg.targets.iter().any(|t| v.target.contains(t)))
                     .filter_map(|v| v.value.map(|val| (v.key, val)))
                     .collect(),
             ),

--- a/crates/cli/src/commands/sync.rs
+++ b/crates/cli/src/commands/sync.rs
@@ -9,6 +9,7 @@ use clap::Args;
 use secrecy::ExposeSecret;
 use serde::{Deserialize, Serialize};
 
+use revvault_core::sync::shape::{self, Shape};
 use revvault_core::sync::vercel::{VercelClient, VercelEnvVar};
 use revvault_core::{Config, PassageStore};
 
@@ -26,10 +27,6 @@ pub struct SyncArgs {
     /// Apply changes (default is dry-run)
     #[arg(long)]
     pub apply: bool,
-
-    /// Pull: import existing Vercel vars into the vault
-    #[arg(long)]
-    pub pull: bool,
 
     /// Vercel API token (or set VERCEL_TOKEN env var)
     #[arg(long)]
@@ -59,33 +56,64 @@ struct ProjectSync {
     /// Skip these env var names (integration-managed, etc.)
     #[serde(default)]
     skip: Vec<String>,
-    /// Per-var path overrides. Maps a Vercel var name to an absolute vault
-    /// path. When a var is in this map, its vault path is the override
-    /// instead of `<vault_prefix>/<VAR_NAME>`.
+    /// Per-var path + optional shape overrides.
     ///
-    /// Use case: one canonical kebab-cased vault path (e.g.
-    /// `revealui/prod/db/postgres-url`) feeding multiple Vercel vars
-    /// (e.g. `POSTGRES_URL` + `DATABASE_URL`) across one or more projects,
-    /// without duplicating the value in the vault.
+    /// Supports two TOML forms for backwards compatibility:
     ///
-    /// TOML form:
+    /// Bare string (path only, shape defaults to `any`):
     /// ```toml
     /// [projects.api.vars]
     /// POSTGRES_URL = "revealui/prod/db/postgres-url"
-    /// DATABASE_URL = "revealui/prod/db/postgres-url"
+    /// ```
+    ///
+    /// Inline table (path + explicit shape):
+    /// ```toml
+    /// [projects.api.vars]
+    /// POSTGRES_URL = { path = "revealui/prod/db/postgres-url", shape = "postgres-url" }
     /// ```
     #[serde(default)]
-    vars: HashMap<String, String>,
+    vars: HashMap<String, VarEntry>,
+}
+
+/// A per-var entry in `[projects.<slug>.vars]`.
+///
+/// `#[serde(untagged)]` makes TOML bare strings parse as `Path(String)`
+/// while inline tables parse as `Object { path, shape }`. Existing manifests
+/// that use bare strings keep working unchanged.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum VarEntry {
+    /// Bare string — path only; shape defaults to `Shape::Any`.
+    Path(String),
+    /// Inline table — path + explicit shape constraint.
+    Object { path: String, shape: Shape },
+}
+
+impl VarEntry {
+    fn path(&self) -> &str {
+        match self {
+            Self::Path(p) => p,
+            Self::Object { path, .. } => path,
+        }
+    }
+
+    fn shape(&self) -> Shape {
+        match self {
+            Self::Path(_) => Shape::Any,
+            Self::Object { shape, .. } => *shape,
+        }
+    }
 }
 
 impl ProjectSync {
-    /// Resolve the vault path for a given Vercel var name. Returns the override
-    /// if one is set in `vars`, otherwise the prefix-derived default.
-    fn vault_path_for(&self, var_name: &str) -> String {
-        self.vars
-            .get(var_name)
-            .cloned()
-            .unwrap_or_else(|| format!("{}/{}", self.vault_prefix, var_name))
+    /// Resolve the vault path + declared shape for a given Vercel var name.
+    /// Returns the override if one is set in `vars`, otherwise the
+    /// prefix-derived default with `Shape::Any`.
+    fn vault_path_for(&self, var_name: &str) -> (String, Shape) {
+        match self.vars.get(var_name) {
+            Some(entry) => (entry.path().to_string(), entry.shape()),
+            None => (format!("{}/{}", self.vault_prefix, var_name), Shape::Any),
+        }
     }
 }
 
@@ -103,8 +131,10 @@ fn default_targets() -> Vec<String> {
 enum DiffAction {
     Add,
     Update,
+    Match,
     Orphan,
     Skip,
+    DropShape,
 }
 
 #[derive(Debug, Serialize)]
@@ -119,10 +149,17 @@ struct DiffEntry {
 #[derive(Serialize)]
 struct AuditEntry {
     timestamp: String,
+    /// One of: "create", "update", "match", "drop-shape", "skip"
     action: String,
     project: String,
     key: String,
+    /// Shape category of the vault value (e.g. "postgres-url", "stripe-key",
+    /// "vercel-envelope", "empty"). Never the value itself.
+    value_shape: String,
+    /// "ok" | "failed"
     result: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
 }
 
 fn append_audit_log(entry: &AuditEntry) -> anyhow::Result<()> {
@@ -162,148 +199,7 @@ pub async fn run(args: SyncArgs, json_output: bool) -> anyhow::Result<()> {
     let store = PassageStore::open(config)?;
     let client = VercelClient::new(token, manifest.team_id.clone());
 
-    if args.pull {
-        return pull_mode(&store, &client, &manifest, args.apply, json_output).await;
-    }
-
     push_mode(&store, &client, &manifest, args.apply, json_output).await
-}
-
-// ── Pull mode: import Vercel vars into vault ────────────────────────────────
-
-/// Pre-write check for vault-path collisions on pull. Multiple Vercel keys
-/// mapping to the same vault path is intentional aliasing (e.g.
-/// `POSTGRES_URL` + `DATABASE_URL` → `revealui/prod/db/postgres-url`), but if
-/// Vercel has drifted and those keys hold different values, naively writing
-/// each in API iteration order would silently overwrite the canonical secret
-/// with whichever entry the API returned last. Refuse the pull and surface
-/// the conflicting keys so the operator can resolve drift on Vercel before
-/// re-running.
-fn detect_path_collisions(
-    project_name: &str,
-    project_cfg: &ProjectSync,
-    remote_vars: &[VercelEnvVar],
-) -> anyhow::Result<()> {
-    let mut by_path: HashMap<String, Vec<(&str, &str)>> = HashMap::new();
-    for var in remote_vars {
-        if project_cfg.skip.contains(&var.key) {
-            continue;
-        }
-        if var.configuration_id.is_some() {
-            continue;
-        }
-        let vault_path = project_cfg.vault_path_for(&var.key);
-        let value = var.value.as_deref().unwrap_or("");
-        by_path
-            .entry(vault_path)
-            .or_default()
-            .push((var.key.as_str(), value));
-    }
-
-    for (path, members) in &by_path {
-        if members.len() < 2 {
-            continue;
-        }
-        let first_value = members[0].1;
-        if members.iter().any(|(_, v)| *v != first_value) {
-            let keys: Vec<&str> = members.iter().map(|(k, _)| *k).collect();
-            bail!(
-                "Vault path collision in project {project_name:?}: vault path {path:?} \
-                 is targeted by Vercel keys {keys:?} with differing values. Resolve the \
-                 drift on Vercel (or remove a per-var override in the manifest) before \
-                 re-running pull."
-            );
-        }
-    }
-    Ok(())
-}
-
-async fn pull_mode(
-    store: &PassageStore,
-    client: &VercelClient,
-    manifest: &SyncManifest,
-    apply: bool,
-    json_output: bool,
-) -> anyhow::Result<()> {
-    for (project_name, project_cfg) in &manifest.projects {
-        let remote_vars = client.list_env_vars(&project_cfg.project_id).await?;
-
-        // Bail before any writes if multiple Vercel keys map to the same
-        // vault path with differing values. See detect_path_collisions docs.
-        detect_path_collisions(project_name, project_cfg, &remote_vars)?;
-
-        if !json_output {
-            println!("\n\x1b[1m{}\x1b[0m (pull)", project_name);
-        }
-
-        let mut imported = 0u32;
-        let mut skipped = 0u32;
-
-        for var in &remote_vars {
-            if project_cfg.skip.contains(&var.key) {
-                skipped += 1;
-                continue;
-            }
-            // Integration-managed vars have a configurationId — skip them
-            if var.configuration_id.is_some() {
-                skipped += 1;
-                continue;
-            }
-
-            let vault_path = project_cfg.vault_path_for(&var.key);
-            let value = var.value.as_deref().unwrap_or("");
-
-            if !json_output {
-                if apply {
-                    print!("  \x1b[32m+\x1b[0m {} ", var.key);
-                } else {
-                    print!("  \x1b[33m~\x1b[0m {} (dry-run) ", var.key);
-                }
-            }
-
-            if apply {
-                store.upsert(&vault_path, value.as_bytes())?;
-                imported += 1;
-                if !json_output {
-                    println!("→ {}", vault_path);
-                }
-                let _ = append_audit_log(&AuditEntry {
-                    timestamp: Utc::now().to_rfc3339(),
-                    action: "pull".to_string(),
-                    project: project_name.clone(),
-                    key: var.key.clone(),
-                    result: "ok".to_string(),
-                });
-            } else {
-                imported += 1;
-                if !json_output {
-                    println!("→ {}", vault_path);
-                }
-            }
-        }
-
-        if json_output {
-            println!(
-                "{}",
-                serde_json::json!({
-                    "project": project_name,
-                    "mode": "pull",
-                    "dry_run": !apply,
-                    "imported": imported,
-                    "skipped": skipped,
-                })
-            );
-        } else {
-            println!(
-                "  {} imported, {} skipped{}",
-                imported,
-                skipped,
-                if !apply { " (dry-run)" } else { "" }
-            );
-        }
-    }
-
-    Ok(())
 }
 
 // ── Push mode: sync vault to Vercel ─────────────────────────────────────────
@@ -317,14 +213,23 @@ async fn push_mode(
 ) -> anyhow::Result<()> {
     for (project_name, project_cfg) in &manifest.projects {
         let remote_vars = client.list_env_vars(&project_cfg.project_id).await?;
-        // Filter remote vars to those targeting at least one of our configured
-        // environments. Without this, when Vercel returns multiple entries with
-        // the same key (one per environment-target combination — Vercel splits
-        // them when the operator created them via separate add operations),
-        // the HashMap below collapses to whichever happens last in iteration,
-        // potentially picking a non-production entry. Updating that entry then
-        // tries to set its target to ours, conflicting with the existing
-        // production entry → 400 Bad Request.
+
+        // Attempt to fetch decrypted values for MATCH detection. Falls back
+        // to None when the token lacks `env:read:decrypted` scope (403),
+        // which causes all existing vars to be treated as needing an update.
+        let remote_decrypted_map: Option<HashMap<String, String>> = match client
+            .list_env_vars_with_values(&project_cfg.project_id)
+            .await
+        {
+            Ok(Some(vars)) => Some(
+                vars.into_iter()
+                    .filter_map(|v| v.value.map(|val| (v.key, val)))
+                    .collect(),
+            ),
+            Ok(None) => None,
+            Err(_) => None,
+        };
+
         let remote_map: HashMap<String, &VercelEnvVar> = remote_vars
             .iter()
             .filter(|v| project_cfg.targets.iter().any(|t| v.target.contains(t)))
@@ -332,8 +237,7 @@ async fn push_mode(
             .collect();
 
         // Build the union of vars to sync: explicit overrides + everything
-        // under the project's vault_prefix. Overrides win — a var name in
-        // `vars` is never read from `<prefix>/<VAR_NAME>` even if both exist.
+        // under the project's vault_prefix.
         let mut vault_var_names: Vec<String> = Vec::new();
         for var_name in project_cfg.vars.keys() {
             vault_var_names.push(var_name.clone());
@@ -363,12 +267,56 @@ async fn push_mode(
                 continue;
             }
 
-            if remote_map.contains_key(var_name) {
+            let (vault_path, declared_shape) = project_cfg.vault_path_for(var_name);
+
+            // Read and validate the vault value before deciding the diff action.
+            let secret_result = store.get(&vault_path);
+            let vault_value = match secret_result {
+                Ok(s) => s,
+                Err(e) => {
+                    if !json_output {
+                        eprintln!(
+                            "  \x1b[31m✗\x1b[0m {} — cannot read vault path {}: {}",
+                            var_name, vault_path, e
+                        );
+                    }
+                    continue;
+                }
+            };
+
+            let raw_value = vault_value.expose_secret();
+            let violation = shape::check(raw_value, declared_shape).err();
+
+            if let Some(ref v) = violation {
                 diff.push(DiffEntry {
                     key: var_name.clone(),
-                    action: DiffAction::Update,
-                    reason: None,
+                    action: DiffAction::DropShape,
+                    reason: Some(format!("shape violation: {v}")),
                 });
+                continue;
+            }
+
+            if remote_map.contains_key(var_name) {
+                // Check for MATCH: if decrypted remote value equals vault value, skip the write.
+                let is_match = remote_decrypted_map
+                    .as_ref()
+                    .and_then(|m| m.get(var_name))
+                    .map(|remote_val| remote_val == raw_value)
+                    .unwrap_or(false);
+
+                if is_match {
+                    diff.push(DiffEntry {
+                        key: var_name.clone(),
+                        action: DiffAction::Match,
+                        reason: None,
+                    });
+                } else {
+                    diff.push(DiffEntry {
+                        key: var_name.clone(),
+                        action: DiffAction::Update,
+                        reason: None,
+                    });
+                }
             } else {
                 diff.push(DiffEntry {
                     key: var_name.clone(),
@@ -378,17 +326,14 @@ async fn push_mode(
             }
         }
 
-        // Detect orphans (in Vercel but not in vault). Use the target-filtered
-        // map's keys so we only surface orphans for the environments we sync —
-        // a var that exists only on preview/development isn't an orphan from
-        // production's perspective.
+        // Detect orphans (in Vercel but not in vault).
         let mut seen_orphans: std::collections::HashSet<String> = std::collections::HashSet::new();
         for remote_var in remote_map.values() {
             if project_cfg.skip.contains(&remote_var.key) {
                 continue;
             }
             if remote_var.configuration_id.is_some() {
-                continue; // Integration-managed
+                continue;
             }
             if !vault_var_names.contains(&remote_var.key) && !seen_orphans.contains(&remote_var.key)
             {
@@ -422,8 +367,10 @@ async fn push_mode(
                 let (symbol, color) = match entry.action {
                     DiffAction::Add => ("+", "\x1b[32m"),
                     DiffAction::Update => ("~", "\x1b[33m"),
+                    DiffAction::Match => ("=", "\x1b[90m"),
                     DiffAction::Orphan => ("!", "\x1b[31m"),
                     DiffAction::Skip => ("-", "\x1b[90m"),
+                    DiffAction::DropShape => ("✗", "\x1b[31m"),
                 };
                 let reason = entry
                     .reason
@@ -437,15 +384,31 @@ async fn push_mode(
         // Apply changes
         if apply {
             for entry in &diff {
-                let vault_path = project_cfg.vault_path_for(&entry.key);
+                let (vault_path, declared_shape) = project_cfg.vault_path_for(&entry.key);
                 match entry.action {
                     DiffAction::Add => {
                         let secret = store.get(&vault_path)?;
+                        let raw = secret.expose_secret();
+
+                        // Shape guard (should already be DROP'd in diff, but be defensive)
+                        if let Err(v) = shape::check(raw, declared_shape) {
+                            let _ = append_audit_log(&AuditEntry {
+                                timestamp: Utc::now().to_rfc3339(),
+                                action: "drop-shape".to_string(),
+                                project: project_name.clone(),
+                                key: entry.key.clone(),
+                                value_shape: shape::classify(raw),
+                                result: "failed".to_string(),
+                                error: Some(v.to_string()),
+                            });
+                            continue;
+                        }
+
                         client
                             .create_env_var(
                                 &project_cfg.project_id,
                                 &entry.key,
-                                secret.expose_secret(),
+                                raw,
                                 &project_cfg.targets,
                             )
                             .await?;
@@ -454,18 +417,35 @@ async fn push_mode(
                             action: "create".to_string(),
                             project: project_name.clone(),
                             key: entry.key.clone(),
+                            value_shape: shape::classify(raw),
                             result: "ok".to_string(),
+                            error: None,
                         });
                     }
                     DiffAction::Update => {
                         let secret = store.get(&vault_path)?;
+                        let raw = secret.expose_secret();
+
+                        if let Err(v) = shape::check(raw, declared_shape) {
+                            let _ = append_audit_log(&AuditEntry {
+                                timestamp: Utc::now().to_rfc3339(),
+                                action: "drop-shape".to_string(),
+                                project: project_name.clone(),
+                                key: entry.key.clone(),
+                                value_shape: shape::classify(raw),
+                                result: "failed".to_string(),
+                                error: Some(v.to_string()),
+                            });
+                            continue;
+                        }
+
                         if let Some(remote) = remote_map.get(&entry.key) {
                             if let Some(ref id) = remote.id {
                                 client
                                     .update_env_var(
                                         &project_cfg.project_id,
                                         id,
-                                        secret.expose_secret(),
+                                        raw,
                                         &project_cfg.targets,
                                     )
                                     .await?;
@@ -474,14 +454,53 @@ async fn push_mode(
                                     action: "update".to_string(),
                                     project: project_name.clone(),
                                     key: entry.key.clone(),
+                                    value_shape: shape::classify(raw),
                                     result: "ok".to_string(),
+                                    error: None,
                                 });
                             }
                         }
                     }
+                    DiffAction::Match => {
+                        let secret = store.get(&vault_path)?;
+                        let raw = secret.expose_secret();
+                        let _ = append_audit_log(&AuditEntry {
+                            timestamp: Utc::now().to_rfc3339(),
+                            action: "match".to_string(),
+                            project: project_name.clone(),
+                            key: entry.key.clone(),
+                            value_shape: shape::classify(raw),
+                            result: "ok".to_string(),
+                            error: None,
+                        });
+                    }
+                    DiffAction::DropShape => {
+                        if !json_output {
+                            eprintln!(
+                                "  \x1b[31m✗\x1b[0m DROP {}: {}",
+                                entry.key,
+                                entry.reason.as_deref().unwrap_or("")
+                            );
+                        }
+                        if let Ok(secret) = store.get(&vault_path) {
+                            let raw = secret.expose_secret();
+                            let _ = append_audit_log(&AuditEntry {
+                                timestamp: Utc::now().to_rfc3339(),
+                                action: "drop-shape".to_string(),
+                                project: project_name.clone(),
+                                key: entry.key.clone(),
+                                value_shape: shape::classify(raw),
+                                result: "failed".to_string(),
+                                error: entry.reason.clone(),
+                            });
+                        }
+                    }
                     DiffAction::Orphan => {
                         if !json_output {
-                            println!("  \x1b[31m⚠\x1b[0m  Orphan: {} (not deleted — remove manually or add to vault)", entry.key);
+                            println!(
+                                "  \x1b[31m⚠\x1b[0m  Orphan: {} (not deleted — remove manually or add to vault)",
+                                entry.key
+                            );
                         }
                     }
                     DiffAction::Skip => {}
@@ -505,7 +524,7 @@ async fn push_mode(
 mod tests {
     use super::*;
 
-    fn project_with_vars(vars: HashMap<String, String>) -> ProjectSync {
+    fn project_with_vars(vars: HashMap<String, VarEntry>) -> ProjectSync {
         ProjectSync {
             project_id: "prj_test".to_string(),
             vault_prefix: "revealui/vercel/api".to_string(),
@@ -515,13 +534,20 @@ mod tests {
         }
     }
 
+    fn project_with_string_vars(vars: HashMap<String, String>) -> ProjectSync {
+        let entries = vars
+            .into_iter()
+            .map(|(k, v)| (k, VarEntry::Path(v)))
+            .collect();
+        project_with_vars(entries)
+    }
+
     #[test]
     fn vault_path_for_returns_prefix_default_when_no_override() {
         let cfg = project_with_vars(HashMap::new());
-        assert_eq!(
-            cfg.vault_path_for("STRIPE_SECRET_KEY"),
-            "revealui/vercel/api/STRIPE_SECRET_KEY"
-        );
+        let (path, shape) = cfg.vault_path_for("STRIPE_SECRET_KEY");
+        assert_eq!(path, "revealui/vercel/api/STRIPE_SECRET_KEY");
+        assert_eq!(shape, Shape::Any);
     }
 
     #[test]
@@ -529,18 +555,30 @@ mod tests {
         let mut vars = HashMap::new();
         vars.insert(
             "POSTGRES_URL".to_string(),
-            "revealui/prod/db/postgres-url".to_string(),
+            VarEntry::Path("revealui/prod/db/postgres-url".to_string()),
         );
         let cfg = project_with_vars(vars);
-        assert_eq!(
-            cfg.vault_path_for("POSTGRES_URL"),
-            "revealui/prod/db/postgres-url"
+        let (path, shape) = cfg.vault_path_for("POSTGRES_URL");
+        assert_eq!(path, "revealui/prod/db/postgres-url");
+        assert_eq!(shape, Shape::Any);
+        let (path2, _) = cfg.vault_path_for("STRIPE_SECRET_KEY");
+        assert_eq!(path2, "revealui/vercel/api/STRIPE_SECRET_KEY");
+    }
+
+    #[test]
+    fn vault_path_for_object_entry_returns_declared_shape() {
+        let mut vars = HashMap::new();
+        vars.insert(
+            "POSTGRES_URL".to_string(),
+            VarEntry::Object {
+                path: "revealui/prod/db/postgres-url".to_string(),
+                shape: Shape::PostgresUrl,
+            },
         );
-        // Non-overridden var still uses the prefix-derived default.
-        assert_eq!(
-            cfg.vault_path_for("STRIPE_SECRET_KEY"),
-            "revealui/vercel/api/STRIPE_SECRET_KEY"
-        );
+        let cfg = project_with_vars(vars);
+        let (path, shape) = cfg.vault_path_for("POSTGRES_URL");
+        assert_eq!(path, "revealui/prod/db/postgres-url");
+        assert_eq!(shape, Shape::PostgresUrl);
     }
 
     #[test]
@@ -548,17 +586,16 @@ mod tests {
         let mut vars = HashMap::new();
         vars.insert(
             "POSTGRES_URL".to_string(),
-            "revealui/prod/db/postgres-url".to_string(),
+            VarEntry::Path("revealui/prod/db/postgres-url".to_string()),
         );
         vars.insert(
             "DATABASE_URL".to_string(),
-            "revealui/prod/db/postgres-url".to_string(),
+            VarEntry::Path("revealui/prod/db/postgres-url".to_string()),
         );
         let cfg = project_with_vars(vars);
-        assert_eq!(
-            cfg.vault_path_for("POSTGRES_URL"),
-            cfg.vault_path_for("DATABASE_URL")
-        );
+        let (path1, _) = cfg.vault_path_for("POSTGRES_URL");
+        let (path2, _) = cfg.vault_path_for("DATABASE_URL");
+        assert_eq!(path1, path2);
     }
 
     #[test]
@@ -571,11 +608,13 @@ mod tests {
         let manifest: SyncManifest = toml::from_str(toml_src).unwrap();
         let api = manifest.projects.get("api").unwrap();
         assert!(api.vars.is_empty());
-        assert_eq!(api.vault_path_for("FOO"), "revealui/vercel/api/FOO");
+        let (path, shape) = api.vault_path_for("FOO");
+        assert_eq!(path, "revealui/vercel/api/FOO");
+        assert_eq!(shape, Shape::Any);
     }
 
     #[test]
-    fn manifest_parses_with_vars_table() {
+    fn manifest_parses_with_string_vars_table() {
         let toml_src = r#"
             [projects.api]
             project_id = "prj_test"
@@ -588,132 +627,57 @@ mod tests {
         let manifest: SyncManifest = toml::from_str(toml_src).unwrap();
         let api = manifest.projects.get("api").unwrap();
         assert_eq!(api.vars.len(), 2);
-        assert_eq!(
-            api.vault_path_for("POSTGRES_URL"),
-            "revealui/prod/db/postgres-url"
-        );
-        assert_eq!(api.vault_path_for("FOO"), "revealui/vercel/api/FOO");
-    }
-
-    fn env_var(key: &str, value: &str) -> VercelEnvVar {
-        VercelEnvVar {
-            id: Some(format!("env_{key}")),
-            key: key.to_string(),
-            value: Some(value.to_string()),
-            target: vec!["production".to_string()],
-            var_type: Some("encrypted".to_string()),
-            configuration_id: None,
-        }
+        let (path, shape) = api.vault_path_for("POSTGRES_URL");
+        assert_eq!(path, "revealui/prod/db/postgres-url");
+        assert_eq!(shape, Shape::Any);
+        let (foo_path, _) = api.vault_path_for("FOO");
+        assert_eq!(foo_path, "revealui/vercel/api/FOO");
     }
 
     #[test]
-    fn detect_path_collisions_passes_when_each_key_maps_to_unique_path() {
-        let cfg = project_with_vars(HashMap::new());
-        let vars = vec![
-            env_var("STRIPE_SECRET_KEY", "sk_live_a"),
-            env_var("STRIPE_WEBHOOK_SECRET", "whsec_b"),
-        ];
-        assert!(detect_path_collisions("api", &cfg, &vars).is_ok());
+    fn manifest_parses_with_object_vars_table() {
+        let toml_src = r#"
+            [projects.api]
+            project_id = "prj_test"
+            vault_prefix = "revealui/vercel/api"
+
+            [projects.api.vars]
+            POSTGRES_URL = { path = "revealui/prod/db/postgres-url", shape = "postgres-url" }
+            STRIPE_SECRET_KEY = { path = "revealui/prod/stripe/secret-key", shape = "stripe-key-live-only" }
+        "#;
+        let manifest: SyncManifest = toml::from_str(toml_src).unwrap();
+        let api = manifest.projects.get("api").unwrap();
+        let (path, shape) = api.vault_path_for("POSTGRES_URL");
+        assert_eq!(path, "revealui/prod/db/postgres-url");
+        assert_eq!(shape, Shape::PostgresUrl);
+        let (_, stripe_shape) = api.vault_path_for("STRIPE_SECRET_KEY");
+        assert_eq!(stripe_shape, Shape::StripeKeyLiveOnly);
     }
 
     #[test]
-    fn detect_path_collisions_passes_when_aliased_keys_have_matching_values() {
-        // POSTGRES_URL and DATABASE_URL both map to the same vault path AND
-        // hold the same Vercel value — intentional aliasing, no drift.
-        let mut overrides = HashMap::new();
-        overrides.insert(
-            "POSTGRES_URL".to_string(),
-            "revealui/prod/db/postgres-url".to_string(),
-        );
-        overrides.insert(
-            "DATABASE_URL".to_string(),
-            "revealui/prod/db/postgres-url".to_string(),
-        );
-        let cfg = project_with_vars(overrides);
-        let same = "postgres://prod.neon/db";
-        let vars = vec![env_var("POSTGRES_URL", same), env_var("DATABASE_URL", same)];
-        assert!(detect_path_collisions("api", &cfg, &vars).is_ok());
+    fn manifest_parses_mixed_string_and_object_vars() {
+        let toml_src = r#"
+            [projects.api]
+            project_id = "prj_test"
+            vault_prefix = "revealui/vercel/api"
+
+            [projects.api.vars]
+            POSTGRES_URL = "revealui/prod/db/postgres-url"
+            STRIPE_KEY = { path = "revealui/prod/stripe/key", shape = "stripe-key-live-only" }
+        "#;
+        let manifest: SyncManifest = toml::from_str(toml_src).unwrap();
+        let api = manifest.projects.get("api").unwrap();
+        let (_, pg_shape) = api.vault_path_for("POSTGRES_URL");
+        assert_eq!(pg_shape, Shape::Any);
+        let (_, stripe_shape) = api.vault_path_for("STRIPE_KEY");
+        assert_eq!(stripe_shape, Shape::StripeKeyLiveOnly);
     }
 
-    #[test]
-    fn detect_path_collisions_errors_when_aliased_keys_have_drifted_values() {
-        // Same alias setup, but Vercel has drifted — POSTGRES_URL and
-        // DATABASE_URL hold different values. Pull must refuse rather than
-        // silently overwrite the canonical secret in API iteration order.
-        let mut overrides = HashMap::new();
-        overrides.insert(
-            "POSTGRES_URL".to_string(),
-            "revealui/prod/db/postgres-url".to_string(),
-        );
-        overrides.insert(
-            "DATABASE_URL".to_string(),
-            "revealui/prod/db/postgres-url".to_string(),
-        );
-        let cfg = project_with_vars(overrides);
-        let vars = vec![
-            env_var("POSTGRES_URL", "postgres://prod.neon/db-A"),
-            env_var("DATABASE_URL", "postgres://prod.neon/db-B"),
-        ];
-        let err = detect_path_collisions("api", &cfg, &vars).unwrap_err();
-        let msg = format!("{err}");
-        assert!(msg.contains("revealui/prod/db/postgres-url"), "got: {msg}");
-        assert!(msg.contains("POSTGRES_URL"), "got: {msg}");
-        assert!(msg.contains("DATABASE_URL"), "got: {msg}");
-        assert!(msg.contains("differing values"), "got: {msg}");
-    }
-
-    #[test]
-    fn detect_path_collisions_ignores_skipped_keys() {
-        // If one of the colliding keys is in `skip`, it doesn't participate
-        // in the drift check (and won't be written either).
-        let mut overrides = HashMap::new();
-        overrides.insert(
-            "POSTGRES_URL".to_string(),
-            "revealui/prod/db/postgres-url".to_string(),
-        );
-        overrides.insert(
-            "DATABASE_URL".to_string(),
-            "revealui/prod/db/postgres-url".to_string(),
-        );
-        let cfg = ProjectSync {
-            project_id: "prj_test".to_string(),
-            vault_prefix: "revealui/vercel/api".to_string(),
-            targets: default_targets(),
-            skip: vec!["DATABASE_URL".to_string()],
-            vars: overrides,
-        };
-        let vars = vec![
-            env_var("POSTGRES_URL", "value-A"),
-            env_var("DATABASE_URL", "value-B"),
-        ];
-        assert!(detect_path_collisions("api", &cfg, &vars).is_ok());
-    }
-
-    #[test]
-    fn detect_path_collisions_ignores_integration_managed_keys() {
-        // Integration-managed env vars (configurationId set) are skipped
-        // during pull; they shouldn't trigger drift errors either.
-        let mut overrides = HashMap::new();
-        overrides.insert(
-            "POSTGRES_URL".to_string(),
-            "revealui/prod/db/postgres-url".to_string(),
-        );
-        overrides.insert(
-            "DATABASE_URL".to_string(),
-            "revealui/prod/db/postgres-url".to_string(),
-        );
-        let cfg = project_with_vars(overrides);
-        let vars = vec![
-            env_var("POSTGRES_URL", "value-A"),
-            VercelEnvVar {
-                id: Some("env_DATABASE_URL".to_string()),
-                key: "DATABASE_URL".to_string(),
-                value: Some("value-B".to_string()),
-                target: vec!["production".to_string()],
-                var_type: Some("encrypted".to_string()),
-                configuration_id: Some("integration_neon".to_string()),
-            },
-        ];
-        assert!(detect_path_collisions("api", &cfg, &vars).is_ok());
+    /// Helper: build a ProjectSync with old-style string vars for tests that
+    /// predate D6 (vault_path_for now returns (path, shape) — these tests
+    /// only care about the path half).
+    #[allow(dead_code)]
+    fn project_string_only(vars: HashMap<String, String>) -> ProjectSync {
+        project_with_string_vars(vars)
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -44,6 +44,8 @@ enum Commands {
     RotationStatus,
     /// Sync vault secrets with external services (e.g., Vercel env vars)
     Sync(commands::sync::SyncArgs),
+    /// Vault-only health check: read every manifest entry, validate shape
+    Doctor(commands::doctor::DoctorArgs),
 }
 
 #[tokio::main]
@@ -70,6 +72,7 @@ async fn main() -> anyhow::Result<()> {
         Commands::Rotate(args) => commands::rotate::run(args).await,
         Commands::RotationStatus => commands::rotate::status(),
         Commands::Sync(args) => commands::sync::run(args, json).await,
+        Commands::Doctor(args) => commands::doctor::run(args),
     };
 
     if let Err(ref e) = result {

--- a/crates/core/src/rotation/config.rs
+++ b/crates/core/src/rotation/config.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::{Result, RevvaultError};
 use crate::rotation::sync_hook::SyncConfig;
+use crate::sync::shape::Shape;
 
 /// Rotation configuration loaded from `<store>/.revvault/rotation.toml`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -43,6 +44,23 @@ pub struct ProviderConfig {
     /// landed.
     #[serde(default)]
     pub verify: Option<String>,
+    /// Optional expected output shape of the rotated value. When set,
+    /// the executor validates the fresh rotation outcome against this
+    /// shape **before** writing it to the vault. A mismatch aborts the
+    /// rotation — the old key remains in place.
+    ///
+    /// The universal structural checks (empty / null-literal /
+    /// Vercel-envelope) always apply regardless of whether
+    /// `output_shape` is declared.
+    ///
+    /// TOML form:
+    /// ```toml
+    /// [providers.my-stripe-key]
+    /// secret_path = "revealui/prod/stripe/secret-key"
+    /// output_shape = "stripe-key-live-only"
+    /// ```
+    #[serde(default)]
+    pub output_shape: Option<Shape>,
 }
 
 impl RotationConfig {

--- a/crates/core/src/rotation/executor.rs
+++ b/crates/core/src/rotation/executor.rs
@@ -26,6 +26,7 @@ use crate::rotation::provider::RotationLogEntry;
 use crate::rotation::providers::build_provider;
 use crate::rotation::sync_hook::{self, SyncLogEntry};
 use crate::store::PassageStore;
+use crate::sync::shape::{self, Shape};
 
 /// Vault path where a provider's key ID is stored between rotations.
 /// e.g. `credentials/vercel/token` → `credentials/vercel/token-id`
@@ -84,7 +85,26 @@ pub async fn execute(
     // 4. Rotate
     let outcome = provider.rotate().await?;
 
-    // 5. Write new key
+    // 5. Validate output shape before writing to vault.
+    //    Universal structural checks (empty / null / envelope) always run.
+    //    Per-shape check runs when `output_shape` is declared.
+    //    On mismatch the rotation ABORTS — old key remains in vault.
+    {
+        let declared = provider_config.output_shape.unwrap_or(Shape::Any);
+        let raw = outcome.new_value.expose_secret();
+        if let Err(violation) = shape::check(raw, declared) {
+            return Err(anyhow::anyhow!(
+                "rotation provider '{}' returned a value that failed shape validation \
+                 ({}); rotation aborted — old key is unchanged. \
+                 Shape category: {}",
+                provider_name,
+                violation,
+                shape::classify(raw),
+            ));
+        }
+    }
+
+    // 5b. Write new key
     store
         .upsert(
             &provider_config.secret_path,

--- a/crates/core/src/rotation/sync_hook.rs
+++ b/crates/core/src/rotation/sync_hook.rs
@@ -16,11 +16,20 @@
 //! (vault is the source of truth, Vercel is downstream). Recovery
 //! after a partial failure is documented at the message site:
 //! `revvault sync vercel --apply --manifest <path>`.
+//!
+//! # Shape validation
+//!
+//! Before sending a value to Vercel, `push_to_vercel` validates it against
+//! the universal structural checks (empty / null-literal / Vercel-envelope).
+//! A failing check logs a `"drop-shape"` entry and skips the API call rather
+//! than propagating a bad value. This catches misbehaving rotation providers
+//! (e.g., a Neon API failure that returns an empty body).
 
 use secrecy::{ExposeSecret as _, SecretString};
 use serde::{Deserialize, Serialize};
 
 use crate::store::PassageStore;
+use crate::sync::shape::{self, Shape, ShapeViolation};
 use crate::sync::vercel::VercelClient;
 
 /// Per-provider sync block. Today only Vercel is supported; this
@@ -69,43 +78,69 @@ fn default_targets() -> Vec<String> {
 /// One row in the per-rotation sync audit. The executor folds the
 /// vector returned by [`apply_sync_after_rotation`] into the rotation
 /// log entry; the JSONL log captures `target`, `status`,
-/// per-env-var and per-vercel-target detail, and an optional error
-/// reason.
+/// per-env-var and per-vercel-target detail, the value shape category,
+/// and an optional error reason.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SyncLogEntry {
     /// Sync target identifier (currently always `"vercel"`).
     pub target: String,
-    /// One of `"success"`, `"failed"`, `"skipped"`.
+    /// One of `"success"`, `"failed"`, `"skipped"`, `"drop-shape"`.
     pub status: String,
     /// Env-var name on the remote target.
     pub env_var: String,
     /// Vercel target environment (e.g. `"production"`,
     /// `"preview"`).
     pub vercel_target: String,
-    /// Failure reason when `status == "failed"`. Never includes
-    /// secret values.
+    /// Shape category of the value (e.g. `"postgres-url"`, `"stripe-key"`,
+    /// `"vercel-envelope"`, `"empty"`). Never includes the value itself.
+    pub value_shape: String,
+    /// Failure reason when `status == "failed"` or `"drop-shape"`. Never
+    /// includes secret values.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
 }
 
 impl SyncLogEntry {
-    fn success(env_var: &str, vercel_target: &str) -> Self {
+    fn success(env_var: &str, vercel_target: &str, value_shape: &str) -> Self {
         Self {
             target: "vercel".into(),
             status: "success".into(),
             env_var: env_var.to_string(),
             vercel_target: vercel_target.to_string(),
+            value_shape: value_shape.to_string(),
             error: None,
         }
     }
 
-    fn failed(env_var: &str, vercel_target: &str, error: impl Into<String>) -> Self {
+    fn failed(
+        env_var: &str,
+        vercel_target: &str,
+        value_shape: &str,
+        error: impl Into<String>,
+    ) -> Self {
         Self {
             target: "vercel".into(),
             status: "failed".into(),
             env_var: env_var.to_string(),
             vercel_target: vercel_target.to_string(),
+            value_shape: value_shape.to_string(),
             error: Some(error.into()),
+        }
+    }
+
+    fn drop_shape(
+        env_var: &str,
+        vercel_target: &str,
+        value_shape: &str,
+        violation: &ShapeViolation,
+    ) -> Self {
+        Self {
+            target: "vercel".into(),
+            status: "drop-shape".into(),
+            env_var: env_var.to_string(),
+            vercel_target: vercel_target.to_string(),
+            value_shape: value_shape.to_string(),
+            error: Some(violation.to_string()),
         }
     }
 }
@@ -152,6 +187,26 @@ async fn push_to_vercel(
     base_url_override: Option<&str>,
     log: &mut Vec<SyncLogEntry>,
 ) {
+    let value_str = new_value.expose_secret();
+    let value_shape = shape::classify(value_str);
+
+    // Universal shape guard: refuse to propagate empty / null / envelope
+    // values to Vercel regardless of declared shape. A misbehaving rotation
+    // provider (e.g., Neon returning an empty HTTP body) hits this guard.
+    if let Err(violation) = shape::check(value_str, Shape::Any) {
+        for ev in &vercel_ref.env_vars {
+            for t in &ev.targets {
+                log.push(SyncLogEntry::drop_shape(
+                    &ev.name,
+                    t,
+                    &value_shape,
+                    &violation,
+                ));
+            }
+        }
+        return;
+    }
+
     // Fetch the Vercel API token from the vault. If we can't read
     // it, the rotation succeeded but no sync can run — record one
     // failed entry per env-var × target.
@@ -163,6 +218,7 @@ async fn push_to_vercel(
                     log.push(SyncLogEntry::failed(
                         &ev.name,
                         t,
+                        &value_shape,
                         format!(
                             "cannot read Vercel API token at '{}': {}",
                             vercel_ref.api_token_path, e
@@ -189,6 +245,7 @@ async fn push_to_vercel(
                     log.push(SyncLogEntry::failed(
                         &ev.name,
                         t,
+                        &value_shape,
                         format!("Vercel list_env_vars failed: {e}"),
                     ));
                 }
@@ -197,13 +254,10 @@ async fn push_to_vercel(
         }
     };
 
-    let value_str = new_value.expose_secret();
-
     for ev in &vercel_ref.env_vars {
         // Find an existing row for this env-var name. Vercel allows
         // multiple rows per name (different `target` arrays); for
-        // sync we update the first match and create otherwise. The
-        // standalone CLI tool uses the same heuristic.
+        // sync we update the first match and create otherwise.
         let existing_id = existing
             .iter()
             .find(|x| x.key == ev.name)
@@ -225,13 +279,18 @@ async fn push_to_vercel(
         match result {
             Ok(()) => {
                 for t in &ev.targets {
-                    log.push(SyncLogEntry::success(&ev.name, t));
+                    log.push(SyncLogEntry::success(&ev.name, t, &value_shape));
                 }
             }
             Err(e) => {
                 let reason = format!("{e}");
                 for t in &ev.targets {
-                    log.push(SyncLogEntry::failed(&ev.name, t, reason.clone()));
+                    log.push(SyncLogEntry::failed(
+                        &ev.name,
+                        t,
+                        &value_shape,
+                        reason.clone(),
+                    ));
                 }
             }
         }
@@ -288,21 +347,31 @@ mod tests {
     }
 
     #[test]
-    fn sync_log_entry_serializes_compactly_when_success() {
-        let e = SyncLogEntry::success("POSTGRES_URL", "production");
+    fn sync_log_entry_serializes_with_value_shape() {
+        let e = SyncLogEntry::success("POSTGRES_URL", "production", "postgres-url");
         let json = serde_json::to_string(&e).unwrap();
-        // No `error` field when None — keeps the JSONL log readable.
         assert!(!json.contains("error"));
         assert!(json.contains(r#""status":"success""#));
         assert!(json.contains(r#""env_var":"POSTGRES_URL""#));
+        assert!(json.contains(r#""value_shape":"postgres-url""#));
     }
 
     #[test]
     fn sync_log_entry_includes_error_when_failed() {
-        let e = SyncLogEntry::failed("POSTGRES_URL", "production", "boom");
+        let e = SyncLogEntry::failed("POSTGRES_URL", "production", "unknown", "boom");
         let json = serde_json::to_string(&e).unwrap();
         assert!(json.contains(r#""status":"failed""#));
         assert!(json.contains(r#""error":"boom""#));
+        assert!(json.contains(r#""value_shape":"unknown""#));
+    }
+
+    #[test]
+    fn sync_log_entry_drop_shape_records_violation() {
+        let v = ShapeViolation::Empty;
+        let e = SyncLogEntry::drop_shape("POSTGRES_URL", "production", "empty", &v);
+        let json = serde_json::to_string(&e).unwrap();
+        assert!(json.contains(r#""status":"drop-shape""#));
+        assert!(json.contains(r#""value_shape":"empty""#));
     }
 
     /// Create a temp store with a generated age identity. Mirrors the
@@ -339,11 +408,6 @@ mod tests {
         (dir, store)
     }
 
-    // Integration: drive apply_sync_after_rotation_inner against a
-    // mockito Vercel + a tempfile-backed PassageStore. Verifies the
-    // full happy-path fan-out — list, update existing (one
-    // env-var), create missing (the second), one log row per
-    // env-var × target.
     #[tokio::test]
     async fn apply_sync_pushes_two_env_vars_one_existing_one_new() {
         let (_dir, store) = setup_temp_store();
@@ -402,11 +466,11 @@ mod tests {
         )
         .await;
 
-        // 2 entries (POSTGRES_URL × 2 targets) + 1 entry (POSTGRES_NEW × 1)
         assert_eq!(log.len(), 3);
         for row in &log {
             assert_eq!(row.target, "vercel");
             assert_eq!(row.status, "success", "row failed: {row:?}");
+            assert_eq!(row.value_shape, "postgres-url");
         }
 
         m_list.assert_async().await;
@@ -417,7 +481,6 @@ mod tests {
     #[tokio::test]
     async fn apply_sync_records_failure_when_token_missing() {
         let (_dir, store) = setup_temp_store();
-        // Note: no api-token written.
 
         let sync = SyncConfig {
             vercel: Some(VercelSyncRef {
@@ -442,5 +505,63 @@ mod tests {
         assert_eq!(log.len(), 1);
         assert_eq!(log[0].status, "failed");
         assert!(log[0].error.as_deref().unwrap_or("").contains("api-token"));
+    }
+
+    /// Proves the bug class: a rotation provider returning an empty string
+    /// must NEVER be pushed to Vercel.
+    #[tokio::test]
+    async fn sync_hook_refuses_empty_rotation_output() {
+        let (_dir, store) = setup_temp_store();
+        store
+            .upsert("credentials/vercel/api-token", b"token-x")
+            .unwrap();
+
+        let sync = SyncConfig {
+            vercel: Some(VercelSyncRef {
+                api_token_path: "credentials/vercel/api-token".into(),
+                project_id: "prj".into(),
+                team_id: None,
+                env_vars: vec![VercelEnvVarRef {
+                    name: "POSTGRES_URL".into(),
+                    targets: vec!["production".into()],
+                }],
+            }),
+        };
+
+        let log =
+            apply_sync_after_rotation_inner(&store, &sync, &SecretString::from(""), None).await;
+
+        assert_eq!(log.len(), 1);
+        assert_eq!(log[0].status, "drop-shape");
+        assert_eq!(log[0].value_shape, "empty");
+    }
+
+    /// Proves the 2026-05-09 incident class: a Vercel v2 envelope must never
+    /// be pushed back to Vercel as a value.
+    #[tokio::test]
+    async fn sync_hook_refuses_envelope_rotation_output() {
+        let (_dir, store) = setup_temp_store();
+        store
+            .upsert("credentials/vercel/api-token", b"token-x")
+            .unwrap();
+
+        let sync = SyncConfig {
+            vercel: Some(VercelSyncRef {
+                api_token_path: "credentials/vercel/api-token".into(),
+                project_id: "prj".into(),
+                team_id: None,
+                env_vars: vec![VercelEnvVarRef {
+                    name: "POSTGRES_URL".into(),
+                    targets: vec!["production".into()],
+                }],
+            }),
+        };
+
+        let envelope = SecretString::from("eyJ2IjoidjIiLCJlcGsiOnsieCI6InRlc3QifX0=");
+        let log = apply_sync_after_rotation_inner(&store, &sync, &envelope, None).await;
+
+        assert_eq!(log.len(), 1);
+        assert_eq!(log[0].status, "drop-shape");
+        assert_eq!(log[0].value_shape, "vercel-envelope");
     }
 }

--- a/crates/core/src/sync/mod.rs
+++ b/crates/core/src/sync/mod.rs
@@ -1,12 +1,14 @@
 //! Outbound sync to external secret stores.
 //!
 //! Sync is a generic capability — `revvault sync vercel` runs it
-//! standalone (whole-project push/pull from a `revvault-vercel.toml`
+//! standalone (whole-project push from a `revvault-vercel.toml`
 //! manifest), and `revvault rotate <provider>` runs it chained (per-secret
 //! push driven by a `[providers.<name>.sync.vercel]` block in
 //! `rotation.toml`). Both flows share the [`vercel::VercelClient`]
 //! transport in this module.
 
+pub mod shape;
 pub mod vercel;
 
+pub use shape::{Shape, ShapeViolation};
 pub use vercel::{VercelClient, VercelEnvVar};

--- a/crates/core/src/sync/shape.rs
+++ b/crates/core/src/sync/shape.rs
@@ -1,0 +1,518 @@
+//! Value-shape validation for outbound sync.
+//!
+//! Shape predicates are used by both `revvault sync vercel` (push_mode) and the
+//! rotation sync hook to gate values before they reach an external store. Three
+//! structural violations — empty, null literal, Vercel v2-envelope — are always
+//! refused regardless of declared shape (they are invalid for any consumer).
+//! Per-shape checks apply on top.
+//!
+//! **No regex** — all checks use prefix matching, length tests, and
+//! character-class predicates only.
+
+use serde::{Deserialize, Serialize};
+
+/// Declared shape of a secret value. Used by the sync manifest and rotation
+/// providers to gate value-write paths.
+///
+/// The empty / null-literal / ciphertext-envelope structural checks run
+/// regardless of declared shape. Per-shape checks apply on top of those
+/// universal guards.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Shape {
+    /// Any non-empty, non-null, non-ciphertext value passes.
+    Any,
+    /// `postgresql://...` or `postgres://...`
+    PostgresUrl,
+    /// `https://...` or `http://...`
+    HttpsUrl,
+    /// `sk_live_*` / `sk_test_*` / `pk_live_*` / `pk_test_*`
+    StripeKey,
+    /// `sk_live_*` or `pk_live_*` exclusively — refuses test keys.
+    StripeKeyLiveOnly,
+    /// `whsec_*`
+    StripeWebhook,
+    /// `price_*` or `prod_*` (Stripe resource IDs)
+    StripeResource,
+    /// `-----BEGIN ... PRIVATE KEY-----` PEM block
+    PemPrivateKey,
+    /// `-----BEGIN PUBLIC KEY-----` PEM block
+    PemPublicKey,
+    /// Hex string of exactly 64 characters (32 random bytes hex-encoded)
+    Hex32,
+    /// Hex string of exactly 128 characters (64 random bytes hex-encoded)
+    Hex64,
+    /// Contains `@` — basic email shape
+    Email,
+    /// One of the literal strings: `production`, `development`, `true`, `false`
+    Flag,
+}
+
+/// Refusal reason; reported to the operator and to the audit log.
+/// The value itself is never included.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ShapeViolation {
+    /// Value is the empty string.
+    Empty,
+    /// Value is exactly the string `"null"`.
+    NullLiteral,
+    /// Value starts with the Vercel v2-envelope base64 prefix (`eyJ2IjoidjIi`).
+    VercelEnvelope,
+    /// Value is structurally valid (non-empty, non-null, non-envelope) but does
+    /// not satisfy the declared shape constraint.
+    WrongShape {
+        expected: Shape,
+        /// Best-effort classification of what the value actually looks like,
+        /// so the operator can diagnose mismatches quickly.
+        actual_hint: String,
+    },
+}
+
+impl std::fmt::Display for ShapeViolation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Empty => write!(f, "value is empty"),
+            Self::NullLiteral => write!(f, "value is the literal string \"null\""),
+            Self::VercelEnvelope => {
+                write!(
+                    f,
+                    "value is a Vercel v2 ciphertext envelope (starts with eyJ2IjoidjIi)"
+                )
+            }
+            Self::WrongShape {
+                expected,
+                actual_hint,
+            } => write!(
+                f,
+                "expected shape {expected:?} but value looks like: {actual_hint}"
+            ),
+        }
+    }
+}
+
+/// Validate `value` against `expected`. Returns `Ok(())` when the value passes
+/// all checks; returns `Err(ShapeViolation)` with the first violation found.
+///
+/// Universal structural checks (empty / null / envelope) run first regardless
+/// of the declared shape variant.
+pub fn check(value: &str, expected: Shape) -> Result<(), ShapeViolation> {
+    if value.is_empty() {
+        return Err(ShapeViolation::Empty);
+    }
+    if value == "null" {
+        return Err(ShapeViolation::NullLiteral);
+    }
+    if value.starts_with("eyJ2IjoidjIi") {
+        return Err(ShapeViolation::VercelEnvelope);
+    }
+
+    match expected {
+        Shape::Any => Ok(()),
+        Shape::PostgresUrl => {
+            if value.starts_with("postgresql://") || value.starts_with("postgres://") {
+                Ok(())
+            } else {
+                Err(shape_mismatch(expected, value))
+            }
+        }
+        Shape::HttpsUrl => {
+            if value.starts_with("https://") || value.starts_with("http://") {
+                Ok(())
+            } else {
+                Err(shape_mismatch(expected, value))
+            }
+        }
+        Shape::StripeKey => {
+            if matches_stripe_key(value) {
+                Ok(())
+            } else {
+                Err(shape_mismatch(expected, value))
+            }
+        }
+        Shape::StripeKeyLiveOnly => {
+            if value.starts_with("sk_live_") || value.starts_with("pk_live_") {
+                Ok(())
+            } else {
+                Err(shape_mismatch(expected, value))
+            }
+        }
+        Shape::StripeWebhook => {
+            if value.starts_with("whsec_") {
+                Ok(())
+            } else {
+                Err(shape_mismatch(expected, value))
+            }
+        }
+        Shape::StripeResource => {
+            if value.starts_with("price_") || value.starts_with("prod_") {
+                Ok(())
+            } else {
+                Err(shape_mismatch(expected, value))
+            }
+        }
+        Shape::PemPrivateKey => {
+            if value.starts_with("-----BEGIN") && value.contains("PRIVATE KEY") {
+                Ok(())
+            } else {
+                Err(shape_mismatch(expected, value))
+            }
+        }
+        Shape::PemPublicKey => {
+            if value.starts_with("-----BEGIN PUBLIC KEY") {
+                Ok(())
+            } else {
+                Err(shape_mismatch(expected, value))
+            }
+        }
+        Shape::Hex32 => {
+            if value.len() == 64 && value.bytes().all(|b| b.is_ascii_hexdigit()) {
+                Ok(())
+            } else {
+                Err(shape_mismatch(expected, value))
+            }
+        }
+        Shape::Hex64 => {
+            if value.len() == 128 && value.bytes().all(|b| b.is_ascii_hexdigit()) {
+                Ok(())
+            } else {
+                Err(shape_mismatch(expected, value))
+            }
+        }
+        Shape::Email => {
+            if value.contains('@') {
+                Ok(())
+            } else {
+                Err(shape_mismatch(expected, value))
+            }
+        }
+        Shape::Flag => {
+            if matches!(value, "production" | "development" | "true" | "false") {
+                Ok(())
+            } else {
+                Err(shape_mismatch(expected, value))
+            }
+        }
+    }
+}
+
+fn shape_mismatch(expected: Shape, value: &str) -> ShapeViolation {
+    ShapeViolation::WrongShape {
+        expected,
+        actual_hint: classify(value),
+    }
+}
+
+fn matches_stripe_key(value: &str) -> bool {
+    value.starts_with("sk_live_")
+        || value.starts_with("sk_test_")
+        || value.starts_with("pk_live_")
+        || value.starts_with("pk_test_")
+}
+
+/// Best-effort categorisation of a value's shape. Used in error messages and
+/// audit-log `value_shape` fields. Never logs the value itself — only the
+/// category name.
+pub fn classify(value: &str) -> String {
+    if value.is_empty() {
+        return "empty".into();
+    }
+    if value == "null" {
+        return "null-literal".into();
+    }
+    if value.starts_with("eyJ2IjoidjIi") {
+        return "vercel-envelope".into();
+    }
+    if value.starts_with("postgresql://") || value.starts_with("postgres://") {
+        return "postgres-url".into();
+    }
+    if value.starts_with("https://") {
+        return "https-url".into();
+    }
+    if value.starts_with("http://") {
+        return "http-url".into();
+    }
+    if matches_stripe_key(value) {
+        return "stripe-key".into();
+    }
+    if value.starts_with("whsec_") {
+        return "stripe-webhook".into();
+    }
+    if value.starts_with("price_") || value.starts_with("prod_") {
+        return "stripe-resource".into();
+    }
+    if value.starts_with("-----BEGIN") && value.contains("PRIVATE KEY") {
+        return "pem-private-key".into();
+    }
+    if value.starts_with("-----BEGIN PUBLIC KEY") {
+        return "pem-public-key".into();
+    }
+    if value.len() == 64 && value.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return "hex32".into();
+    }
+    if value.len() == 128 && value.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return "hex64".into();
+    }
+    if value.contains('@') {
+        return "email".into();
+    }
+    if matches!(value, "production" | "development" | "true" | "false") {
+        return "flag".into();
+    }
+    "unknown".into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ENVELOPE: &str = "eyJ2IjoidjIiLCJlcGsiOnsieCI6InRlc3QifX0=";
+
+    fn all_shapes() -> Vec<Shape> {
+        vec![
+            Shape::Any,
+            Shape::PostgresUrl,
+            Shape::HttpsUrl,
+            Shape::StripeKey,
+            Shape::StripeKeyLiveOnly,
+            Shape::StripeWebhook,
+            Shape::StripeResource,
+            Shape::PemPrivateKey,
+            Shape::PemPublicKey,
+            Shape::Hex32,
+            Shape::Hex64,
+            Shape::Email,
+            Shape::Flag,
+        ]
+    }
+
+    #[test]
+    fn check_empty_always_rejected() {
+        for shape in all_shapes() {
+            assert_eq!(
+                check("", shape),
+                Err(ShapeViolation::Empty),
+                "shape {shape:?} should reject empty"
+            );
+        }
+    }
+
+    #[test]
+    fn check_null_literal_always_rejected() {
+        for shape in all_shapes() {
+            assert_eq!(
+                check("null", shape),
+                Err(ShapeViolation::NullLiteral),
+                "shape {shape:?} should reject \"null\""
+            );
+        }
+    }
+
+    #[test]
+    fn check_envelope_always_rejected() {
+        for shape in all_shapes() {
+            assert_eq!(
+                check(ENVELOPE, shape),
+                Err(ShapeViolation::VercelEnvelope),
+                "shape {shape:?} should reject Vercel envelope"
+            );
+        }
+    }
+
+    #[test]
+    fn check_any_accepts_non_empty_non_null_non_envelope() {
+        assert!(check("some-value", Shape::Any).is_ok());
+        assert!(check("postgresql://host/db", Shape::Any).is_ok());
+        assert!(check("literally-anything", Shape::Any).is_ok());
+    }
+
+    #[test]
+    fn check_postgres_url_accepts_both_prefixes() {
+        assert!(check("postgresql://host/db", Shape::PostgresUrl).is_ok());
+        assert!(check("postgres://host/db", Shape::PostgresUrl).is_ok());
+    }
+
+    #[test]
+    fn check_postgres_url_rejects_non_postgres() {
+        assert!(check("mysql://host/db", Shape::PostgresUrl).is_err());
+        assert!(check("https://host/db", Shape::PostgresUrl).is_err());
+    }
+
+    #[test]
+    fn check_https_url_accepts_both_schemes() {
+        assert!(check("https://example.com/api", Shape::HttpsUrl).is_ok());
+        assert!(check("http://localhost:3000", Shape::HttpsUrl).is_ok());
+    }
+
+    #[test]
+    fn check_https_url_rejects_non_http() {
+        assert!(check("ftp://example.com", Shape::HttpsUrl).is_err());
+        assert!(check("postgresql://host/db", Shape::HttpsUrl).is_err());
+    }
+
+    #[test]
+    fn check_stripe_key_accepts_all_four_prefixes() {
+        assert!(check("sk_live_abc123", Shape::StripeKey).is_ok());
+        assert!(check("sk_test_abc123", Shape::StripeKey).is_ok());
+        assert!(check("pk_live_abc123", Shape::StripeKey).is_ok());
+        assert!(check("pk_test_abc123", Shape::StripeKey).is_ok());
+    }
+
+    #[test]
+    fn check_stripe_key_rejects_others() {
+        assert!(check("whsec_abc123", Shape::StripeKey).is_err());
+        assert!(check("rk_live_abc123", Shape::StripeKey).is_err());
+    }
+
+    #[test]
+    fn check_stripe_key_live_only_rejects_test_keys() {
+        assert!(check("sk_live_abc", Shape::StripeKeyLiveOnly).is_ok());
+        assert!(check("pk_live_abc", Shape::StripeKeyLiveOnly).is_ok());
+        assert!(check("sk_test_abc", Shape::StripeKeyLiveOnly).is_err());
+        assert!(check("pk_test_abc", Shape::StripeKeyLiveOnly).is_err());
+    }
+
+    #[test]
+    fn check_stripe_webhook_accepts_whsec() {
+        assert!(check("whsec_abc123", Shape::StripeWebhook).is_ok());
+        assert!(check("sk_live_abc", Shape::StripeWebhook).is_err());
+    }
+
+    #[test]
+    fn check_stripe_resource_accepts_price_and_prod_prefixes() {
+        assert!(check("price_abc123", Shape::StripeResource).is_ok());
+        assert!(check("prod_abc123", Shape::StripeResource).is_ok());
+        assert!(check("sub_abc123", Shape::StripeResource).is_err());
+    }
+
+    #[test]
+    fn check_pem_private_key_accepts_pem_block() {
+        let pem = "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgk\n-----END PRIVATE KEY-----";
+        assert!(check(pem, Shape::PemPrivateKey).is_ok());
+        let ec_pem = "-----BEGIN EC PRIVATE KEY-----\ndata\n-----END EC PRIVATE KEY-----";
+        assert!(check(ec_pem, Shape::PemPrivateKey).is_ok());
+    }
+
+    #[test]
+    fn check_pem_private_key_rejects_non_pem() {
+        assert!(check("postgresql://host", Shape::PemPrivateKey).is_err());
+        assert!(check("-----BEGIN PUBLIC KEY-----", Shape::PemPrivateKey).is_err());
+    }
+
+    #[test]
+    fn check_pem_public_key() {
+        assert!(check(
+            "-----BEGIN PUBLIC KEY-----\ndata\n-----END PUBLIC KEY-----",
+            Shape::PemPublicKey
+        )
+        .is_ok());
+        assert!(check("-----BEGIN PRIVATE KEY-----\ndata", Shape::PemPublicKey).is_err());
+    }
+
+    #[test]
+    fn check_hex32_accepts_64_char_hex() {
+        let hex64 = "a".repeat(64);
+        assert!(check(&hex64, Shape::Hex32).is_ok());
+        let valid = "0123456789abcdefABCDEF".repeat(2) + "01234567890123456789";
+        assert_eq!(valid.len(), 64);
+        assert!(check(&valid, Shape::Hex32).is_ok());
+    }
+
+    #[test]
+    fn check_hex32_rejects_wrong_length() {
+        assert!(check(&"a".repeat(63), Shape::Hex32).is_err());
+        assert!(check(&"a".repeat(65), Shape::Hex32).is_err());
+    }
+
+    #[test]
+    fn check_hex32_rejects_non_hex_chars() {
+        let with_g = "g".repeat(64);
+        assert!(check(&with_g, Shape::Hex32).is_err());
+    }
+
+    #[test]
+    fn check_hex64_accepts_128_char_hex() {
+        let hex128 = "b".repeat(128);
+        assert!(check(&hex128, Shape::Hex64).is_ok());
+    }
+
+    #[test]
+    fn check_hex64_rejects_64_chars() {
+        assert!(check(&"b".repeat(64), Shape::Hex64).is_err());
+    }
+
+    #[test]
+    fn check_email_accepts_value_containing_at() {
+        assert!(check("user@example.com", Shape::Email).is_ok());
+        assert!(check("a@b", Shape::Email).is_ok());
+    }
+
+    #[test]
+    fn check_email_rejects_no_at() {
+        assert!(check("notanemail", Shape::Email).is_err());
+    }
+
+    #[test]
+    fn check_flag_accepts_known_literals() {
+        assert!(check("production", Shape::Flag).is_ok());
+        assert!(check("development", Shape::Flag).is_ok());
+        assert!(check("true", Shape::Flag).is_ok());
+        assert!(check("false", Shape::Flag).is_ok());
+    }
+
+    #[test]
+    fn check_flag_rejects_other_strings() {
+        assert!(check("staging", Shape::Flag).is_err());
+        assert!(check("1", Shape::Flag).is_err());
+    }
+
+    #[test]
+    fn classify_returns_correct_categories() {
+        assert_eq!(classify(""), "empty");
+        assert_eq!(classify("null"), "null-literal");
+        assert_eq!(classify(ENVELOPE), "vercel-envelope");
+        assert_eq!(classify("postgresql://h/db"), "postgres-url");
+        assert_eq!(classify("postgres://h/db"), "postgres-url");
+        assert_eq!(classify("https://example.com"), "https-url");
+        assert_eq!(classify("http://localhost"), "http-url");
+        assert_eq!(classify("sk_live_abc"), "stripe-key");
+        assert_eq!(classify("sk_test_abc"), "stripe-key");
+        assert_eq!(classify("whsec_abc"), "stripe-webhook");
+        assert_eq!(classify("price_abc"), "stripe-resource");
+        assert_eq!(
+            classify("-----BEGIN PRIVATE KEY-----\nk\n-----END PRIVATE KEY-----"),
+            "pem-private-key"
+        );
+        assert_eq!(classify("-----BEGIN PUBLIC KEY-----"), "pem-public-key");
+        assert_eq!(classify(&"a".repeat(64)), "hex32");
+        assert_eq!(classify(&"a".repeat(128)), "hex64");
+        assert_eq!(classify("user@host.com"), "email");
+        assert_eq!(classify("production"), "flag");
+        assert_eq!(classify("some-random-value"), "unknown");
+    }
+
+    #[test]
+    fn shape_serde_round_trip_kebab_case() {
+        let shape = Shape::PostgresUrl;
+        let json = serde_json::to_string(&shape).unwrap();
+        assert_eq!(json, r#""postgres-url""#);
+        let back: Shape = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, Shape::PostgresUrl);
+    }
+
+    #[test]
+    fn shape_violation_display_is_human_readable() {
+        let v = ShapeViolation::Empty;
+        assert!(v.to_string().contains("empty"));
+        let v = ShapeViolation::NullLiteral;
+        assert!(v.to_string().contains("null"));
+        let v = ShapeViolation::VercelEnvelope;
+        assert!(v.to_string().contains("Vercel"));
+        let v = ShapeViolation::WrongShape {
+            expected: Shape::StripeKey,
+            actual_hint: "postgres-url".into(),
+        };
+        assert!(v.to_string().contains("StripeKey"));
+        assert!(v.to_string().contains("postgres-url"));
+    }
+}

--- a/crates/core/src/sync/vercel.rs
+++ b/crates/core/src/sync/vercel.rs
@@ -149,6 +149,35 @@ impl VercelClient {
         Ok(data.envs)
     }
 
+    /// List env vars with decrypted values via `decrypt=true`.
+    ///
+    /// Requires the `env:read:decrypted` scope on the Vercel token. Returns
+    /// `Ok(None)` when the token lacks the scope (403) so callers can fall
+    /// back to assume-drift rather than hard-failing. Any other non-success
+    /// status is returned as `Err`.
+    pub async fn list_env_vars_with_values(
+        &self,
+        project_id: &str,
+    ) -> anyhow::Result<Option<Vec<VercelEnvVar>>> {
+        let base = self.base_url(project_id);
+        let separator = if base.contains('?') { '&' } else { '?' };
+        let url = format!("{base}{separator}decrypt=true");
+        let req = self.client.get(&url).bearer_auth(&self.token);
+        let resp = self.send_retrying(req).await?;
+
+        if resp.status() == reqwest::StatusCode::FORBIDDEN {
+            return Ok(None);
+        }
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            bail!("Vercel API (decrypt=true) returned {}: {}", status, body);
+        }
+
+        let data: VercelEnvListResponse = resp.json().await?;
+        Ok(Some(data.envs))
+    }
+
     /// Create a new env var. The Vercel API rejects duplicates with
     /// 409; callers detect existing rows via [`Self::list_env_vars`]
     /// + dispatch to [`Self::update_env_var`] when present.

--- a/crates/core/tests/rotation_integration.rs
+++ b/crates/core/tests/rotation_integration.rs
@@ -398,6 +398,7 @@ async fn executor_writes_new_key_to_vault_and_logs() {
         sync: None,
         post_rotate: vec![],
         verify: None,
+        output_shape: None,
     };
 
     executor::execute(&store, "svc", &provider_config)
@@ -462,6 +463,7 @@ async fn executor_uses_stored_key_id_for_revocation() {
         sync: None,
         post_rotate: vec![],
         verify: None,
+        output_shape: None,
     };
 
     executor::execute(&store, "svc", &provider_config)
@@ -487,6 +489,7 @@ async fn executor_local_hex32_writes_64_hex_chars_to_vault() {
         sync: None,
         post_rotate: vec![],
         verify: None,
+        output_shape: None,
     };
 
     executor::execute(&store, "internal", &provider_config)
@@ -512,6 +515,7 @@ async fn executor_local_hex64_writes_128_hex_chars_to_vault() {
         sync: None,
         post_rotate: vec![],
         verify: None,
+        output_shape: None,
     };
 
     executor::execute(&store, "internal", &provider_config)
@@ -534,6 +538,7 @@ async fn executor_local_uuid_writes_uuid_v4_to_vault() {
         sync: None,
         post_rotate: vec![],
         verify: None,
+        output_shape: None,
     };
 
     executor::execute(&store, "internal", &provider_config)
@@ -560,6 +565,7 @@ async fn local_factory_rejects_missing_generator_type() {
         sync: None,
         post_rotate: vec![],
         verify: None,
+        output_shape: None,
     };
 
     let err = executor::execute(&store, "internal", &provider_config)
@@ -581,6 +587,7 @@ async fn local_factory_rejects_unknown_generator_type() {
         sync: None,
         post_rotate: vec![],
         verify: None,
+        output_shape: None,
     };
 
     let err = executor::execute(&store, "internal", &provider_config)
@@ -617,6 +624,7 @@ async fn executor_runs_post_rotate_hooks_in_order() {
             format!("touch '{marker_b_sh}'"),
         ],
         verify: None,
+        output_shape: None,
     };
 
     executor::execute(&store, "seq", &provider_config)
@@ -637,6 +645,7 @@ async fn executor_post_rotate_failure_does_not_abort_rotation() {
         sync: None,
         post_rotate: vec!["false".into()], // exits 1
         verify: None,
+        output_shape: None,
     };
 
     // post_rotate hook is warn-only, so this must succeed.
@@ -667,6 +676,7 @@ async fn executor_verify_success_logs_verified_true() {
         sync: None,
         post_rotate: vec![],
         verify: Some("true".into()), // exits 0
+        output_shape: None,
     };
 
     executor::execute(&store, "verify-ok", &provider_config)
@@ -688,6 +698,7 @@ async fn executor_no_verify_omits_verified_field_in_log() {
         sync: None,
         post_rotate: vec![],
         verify: None,
+        output_shape: None,
     };
 
     executor::execute(&store, "no-verify", &provider_config)
@@ -714,6 +725,7 @@ async fn executor_verify_failure_returns_err_and_logs_verified_false() {
         sync: None,
         post_rotate: vec![],
         verify: Some("false".into()), // exits 1
+        output_shape: None,
     };
 
     let err = executor::execute(&store, "verify-fail", &provider_config)
@@ -756,6 +768,7 @@ async fn executor_verify_failure_with_post_rotate_still_runs_post_rotate() {
         sync: None,
         post_rotate: vec![format!("touch '{marker_sh}'")],
         verify: Some("false".into()), // exits 1 — strict failure
+        output_shape: None,
     };
 
     let _err = executor::execute(&store, "seq-and-fail", &provider_config)

--- a/docs/MASTER_SPEC.md
+++ b/docs/MASTER_SPEC.md
@@ -66,9 +66,9 @@ The frontend never touches `core` directly — it goes through `tauri-app` IPC. 
 | `revvault export-env [<prefix>]` | Materialize `.env`-shaped output for direnv | `revvault export-env revealui/dev/ > .envrc.secret` |
 | `revvault generate` | Generate a strong password (CSPRNG) | `revvault generate \| revvault set credentials/new` |
 | `revvault sync vercel [--manifest <path>]` | Show diff between vault + Vercel env vars (default = dry-run; manifest defaults to `revvault-vercel.toml`) | `revvault sync vercel --manifest revvault-vercel.toml` |
-| `revvault sync vercel --apply [--manifest <path>]` | Actually write the diff to Vercel | `revvault sync vercel --apply` |
-| `revvault sync vercel --pull [--manifest <path>]` | Import existing Vercel vars into the vault | `revvault sync vercel --pull` |
+| `revvault sync vercel --apply [--manifest <path>]` | Push vault values to Vercel; shape-validates each value before the API call | `revvault sync vercel --apply` |
 | `revvault sync vercel --token <token> ...` | Override Vercel API token (or set `VERCEL_TOKEN` env var) | `revvault sync vercel --apply --token $VERCEL_TOKEN` |
+| `revvault doctor [--manifest <path>] [--json]` | **0.2.0+** Vault-only health check — validates every manifest entry against its declared shape; exit 0 = all pass, exit 1 = failures found. Never touches Vercel. | `revvault doctor --manifest revvault-vercel.toml` |
 
 ### Path conventions
 


### PR DESCRIPTION
## Summary

Durable redesign of `revvault sync` — incident response to the 2026-05-09 production outage (5-day downtime; `sync vercel --pull` overwrote 53 canonical vault paths with ciphertext/empty values when Vercel's list API changed behavior).

Implements the **owner-approved spec** `revvault-sync-durable-redesign.md` (`status: APPROVED` 2026-05-14, all 6 sign-off questions resolved). Single PR, all 7 design items (D1–D7).

## What changed

| D | Change |
|---|--------|
| **D1** | **Remove `--pull` entirely.** The inverted-direction primitive (Vercel → vault) is deleted — `pull` arg, `pull_mode`, `detect_path_collisions` and its tests all gone. The vault is now the only writable source; downstream copies are derivable. |
| **D2** | **Shape validation** (`crates/core/src/sync/shape.rs`, new). Universal structural checks (empty / `null` literal / Vercel v2 ciphertext-envelope) run unconditionally; typed shapes (`postgres-url`, `stripe-key`, `hex32`, …) via prefix/length/char-class predicates. **No regex** (per `feedback_no_regex_ast_only`). Wired into `push_mode` and the rotation `push_to_vercel` hook — a violating value is dropped with a `drop-shape` audit entry, the rest of the run continues. |
| **D3** | **`revvault doctor`** subcommand — vault-only health check, touches no external system. Exit 1 on any violation. Would have caught the 2026-05-09 corruption in seconds. |
| **D4** | **Value-diff + MATCH skip** on push. `VercelClient::list_env_vars_with_values` uses `decrypt=true`; unchanged vars classify as `Match` and skip the API call. Missing `env:read:decrypted` token scope → 403 → graceful fallback to assume-drift (current behavior). |
| **D5** | **Audit log records `value_shape`** on every push/match/drop entry (both `AuditEntry` and the rotation `SyncLogEntry`) — a corrupted write is now detectable from log review alone. Records shape *category* only, never the value. |
| **D6** | **Manifest schema evolution.** `#[serde(untagged)]` `VarEntry { Path(String) \| Object { path, shape } }`. Bare-string entries parse as `shape = "any"` — existing manifests work unchanged; shapes added incrementally. |
| **D7** | **Rotation provider `output_shape`** (optional). `executor.rs` validates the rotated value against the declared shape *before* `store.upsert` — mismatch aborts the rotation, the old key stays in place. |

Plus: `CHANGELOG.md` (new), version bump `0.1.0 → 0.2.0` (minor — breaking change within 0.x per versioning.md), `docs/MASTER_SPEC.md` `--pull` row updated.

## Verification

- `cargo build --workspace` — clean
- `cargo clippy --workspace -- -D warnings` — zero warnings
- `cargo test --workspace` — **90 tests pass** (49 core + 41 cli), 0 failed
- `cargo fmt --check` — clean
- New tests cover the bug class that shipped the incident: push refuses empty / `null` / ciphertext-envelope values; audit entries record `value_shape: "empty"` / `"vercel-envelope"`.

## Follow-up (separate, not in this PR)

`--pull` removal leaves two dead consumers in the **revealui** repo: `package.json` scripts `vercel:sync:pull` / `vercel:sync:pull:apply` and a `MASTER_PLAN.md` bootstrap reference. Those need a separate revealui-side cleanup PR.

## Closes

Supersedes GAP-201 (tactical "show drift on pull" fix — closed as superseded by this durable redesign).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
