### PR TITLE
docs(index): add fleet-anchor INDEX.md (cold-context agent ramp)

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,0 +1,26 @@
+---
+type: repo-doc-index
+repo: revvault
+updated: 2026-05-15
+---
+
+# RevVault — Documentation Index
+
+Age-encrypted credential vault for RevFleet. CLI + Tauri desktop app + MCP server.
+
+## This repo's masters
+
+- [`MASTER_PLAN.md`](./MASTER_PLAN.md) — authoritative plan for RevVault
+- [`MASTER_SPEC.md`](./MASTER_SPEC.md) — design spec
+
+## Fleet coordination
+
+Part of [RevFleet](https://github.com/RevealUIStudio). For agents working in `~/revfleet/revvault/`:
+
+- Fleet master index: `~/revfleet/.jv/docs/MASTER_INDEX.md`
+- Fleet master plan: `~/revfleet/.jv/docs/MASTER_PLAN.md`
+- Active lanes (multi-session work): `~/revfleet/.jv/docs/lanes/`
+  - Notably: `~/revfleet/.jv/docs/lanes/revvault-rotation/` — rotation engine + Vercel sync (revvault's primary cross-repo endeavor)
+- GAP tracker: `~/revfleet/.jv/docs/gaps/` + `~/revfleet/.jv/docs/gap-specs/`
+- Live workboard: `~/revfleet/.jv/.claude/workboard.md`
+- ADR for lanes convention: `~/revfleet/.jv/docs/decisions/2026-05-15-docs-organization-lanes.md`

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -15,12 +15,4 @@ Age-encrypted credential vault for RevFleet. CLI + Tauri desktop app + MCP serve
 
 ## Fleet coordination
 
-Part of [RevFleet](https://github.com/RevealUIStudio). For agents working in `~/revfleet/revvault/`:
-
-- Fleet master index: `~/revfleet/.jv/docs/MASTER_INDEX.md`
-- Fleet master plan: `~/revfleet/.jv/docs/MASTER_PLAN.md`
-- Active lanes (multi-session work): `~/revfleet/.jv/docs/lanes/`
-  - Notably: `~/revfleet/.jv/docs/lanes/revvault-rotation/` — rotation engine + Vercel sync (revvault's primary cross-repo endeavor)
-- GAP tracker: `~/revfleet/.jv/docs/gaps/` + `~/revfleet/.jv/docs/gap-specs/`
-- Live workboard: `~/revfleet/.jv/.claude/workboard.md`
-- ADR for lanes convention: `~/revfleet/.jv/docs/decisions/2026-05-15-docs-organization-lanes.md`
+Part of [RevFleet](https://github.com/RevealUIStudio). Cross-fleet coordination, planning, and lane tracking live in the agent dev environment — not in this public repo.


### PR DESCRIPTION
## Summary

Adds `docs/INDEX.md` as a cold-context anchor for this repo. When an agent (or any cold reader) lands here from scratch, INDEX.md points them at:

- This repo's `MASTER_PLAN.md` + `MASTER_SPEC.md`
- Fleet master index, master plan, lanes/, gaps/, workboard (internal paths under `~/revfleet/internal docs/`, agent-readable when working locally)
- ADR `2026-05-15-docs-organization-lanes` (the lanes/ convention)

Improvement 3 of the 2026-05-15 docs reorg. Companion to:
- an internal repo ADR `docs/decisions/2026-05-15-docs-organization-lanes.md`
- an internal repo `lanes/` structure

## Test plan

- [ ] File renders correctly on GitHub
- [ ] Frontmatter is well-formed YAML
- [ ] No CI dependencies (single new file, no consumers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
