### PR TITLE
docs(readme): refresh root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,20 @@
-# Revvault
+# RevVault
 
-Age-encrypted secret vault with CLI and Tauri desktop app. 100% [passage](https://github.com/FiloSottile/passage)-compatible.
+> The canonical secret store for the entire RevFleet. Age-encrypted vault with CLI and Tauri desktop app. 100% [passage](https://github.com/FiloSottile/passage)-compatible.
+
+Per the fleet-wide [secrets rule](https://github.com/RevealUIStudio/revealui/blob/main/.claude/rules/secrets.md), every secret RevealUI depends on lives here — API keys, database URLs, webhook secrets, JWT/session keys, Solana keypairs, license keys, OAuth client secrets, age identities, SSH keys, anything else. One encryption boundary (the age identity) gates the whole fleet; rotation updates one store and downstream systems (CI secrets, Vercel envelopes) re-read from the same source.
 
 ## Features
 
-- **Encrypted at rest** — secrets stored as `.age` files using x25519 key exchange
-- **CLI** — `revvault get`, `set`, `list`, `search`, `delete`, `edit`, `export-env`
+- **Encrypted at rest** — `.age` files using x25519 key exchange
+- **CLI** — `revvault get`, `set`, `list`, `search`, `delete`, `edit`, `export-env`, plus `--json` for structured output
 - **Desktop app** — Tauri 2 + React 19 with search, browse, create, reveal, copy, delete
-- **Namespaces** — secrets organized by first path segment (credentials, ssh, misc, etc.)
+- **Namespaces** — secrets organized by first path segment (`revealui/`, `revealcoin/`, `revforge/`, `credentials/`, `ssh/`)
 - **Fuzzy search** — find secrets by partial path match
 - **Import** — migrate plaintext secret files with automatic categorization
+- **Rotation** — `crates/core` includes rotation helpers for high-frequency rotation paths
 - **Path validation** — directory traversal and injection attacks blocked
+- **Downstream sync** — propagates to GitHub Actions secrets + Vercel encrypted envelopes via `scripts/sync/revvault-vercel.toml` in the RevealUI repo (downstream mirror, not source of truth)
 
 ## Quick Start
 
@@ -22,8 +26,8 @@ Age-encrypted secret vault with CLI and Tauri desktop app. 100% [passage](https:
 ### Build
 
 ```bash
-cd /path/to/revault
-nix develop
+cd ~/revfleet/revvault
+direnv allow  # or: nix develop
 cargo build --workspace
 ```
 
@@ -31,15 +35,18 @@ cargo build --workspace
 
 ```bash
 # Store a secret
-echo "sk_live_abc123" | revvault set credentials/stripe/secret-key
+echo "sk_live_abc123" | revvault set revealui/prod/stripe/secret-key
 
 # Retrieve it
-revvault get credentials/stripe/secret-key
+revvault get revealui/prod/stripe/secret-key
+
+# Structured output (use --json in scripts — bare `revvault get` is silent in $(...))
+revvault --json get revealui/prod/stripe/secret-key | jq -r .value
 
 # Copy to clipboard
-revvault get credentials/stripe/secret-key --clip
+revvault get revealui/prod/stripe/secret-key --clip
 
-# List all secrets
+# List
 revvault list
 revvault list --tree
 
@@ -47,13 +54,13 @@ revvault list --tree
 revvault search stripe
 
 # Edit in $EDITOR
-revvault edit credentials/stripe/secret-key
+revvault edit revealui/prod/stripe/secret-key
 
 # Export as KEY=VALUE for shell eval
-eval "$(revvault export-env credentials/stripe/secret-key)"
+eval "$(revvault export-env revealui/prod/stripe/secret-key)"
 
 # Delete
-revvault delete credentials/stripe/secret-key
+revvault delete revealui/prod/stripe/secret-key
 
 # Shell completions
 revvault completions bash >> ~/.bashrc
@@ -66,14 +73,32 @@ nix develop
 cargo tauri dev
 ```
 
+## Canonical paths
+
+Paths are lower-kebab, grouped by repo or product, then by subsystem:
+
+| Pattern | Example |
+|---|---|
+| `revealui/dev/<subsystem>/<name>` | `revealui/dev/electric/service-url`, `revealui/dev/admin-session-cookie` |
+| `revealui/prod/<subsystem>/<name>` | `revealui/prod/neon/postgres-url`, `revealui/prod/stripe/secret-key`, `revealui/prod/stripe/webhook-secret` |
+| `revealui/prod/storage/r2/<name>` | `revealui/prod/storage/r2/access-key-id` |
+| `revealcoin/<keypair>` | `revealcoin/mint-authority.json` |
+| `revforge/customers/<slug>/<name>` | `revforge/customers/allevia/admin-password` |
+| `revdev/<name>` | `revdev/license-signing-key` |
+| `credentials/<system>/<name>` | `credentials/github/personal-token`, `credentials/anthropic/api-key` |
+
+New paths get a `docs/SECRETS.md` entry in the relevant repo. Mirroring to CI is a publish step, never hand-typed.
+
 ## Architecture
 
 ```
-crates/core       — shared library (store, crypto, identity, config, namespaces)
+crates/core       — shared library (store, crypto, identity, config, namespaces, import, rotation)
 crates/cli        — revvault CLI binary (clap)
 crates/tauri-app  — Tauri 2 desktop backend
 frontend/         — React 19 + TypeScript + Tailwind CSS v4 (Vite)
 ```
+
+Workspace at version `0.2.0` (pre-1.0 per fleet versioning).
 
 ## Store Format
 
@@ -82,24 +107,30 @@ Secrets live in a directory hierarchy as `.age` files:
 ```
 ~/.revealui/passage-store/
 ├── .age-recipients
+├── revealui/
+│   ├── dev/
+│   │   └── electric/service-url.age
+│   └── prod/
+│       ├── neon/postgres-url.age
+│       └── stripe/secret-key.age
+├── revealcoin/
+│   └── mint-authority.json.age
+├── revforge/
+│   └── customers/
+│       └── allevia/admin-password.age
 ├── credentials/
-│   └── stripe/
-│       ├── secret-key.age
-│       └── publishable-key.age
-├── ssh/
-│   └── github.age
-└── misc/
-    └── note.age
+│   └── github/personal-token.age
+└── ssh/
+    └── github.age
 ```
 
-Override the store location with `REVVAULT_STORE` env var.
-Override the identity file with `REVVAULT_IDENTITY` env var.
+Override the store location with `REVVAULT_STORE`. Override the identity file with `REVVAULT_IDENTITY`.
 
 ## Development
 
 ```bash
 # Enter dev shell
-nix develop
+direnv allow  # or: nix develop
 
 # Run all CI checks (fmt, clippy, tests, frontend build)
 bash scripts/ci.sh
@@ -112,6 +143,8 @@ cargo test -p revvault-core
 cargo test -p revvault-cli
 ```
 
+Library errors use `thiserror`; binary errors use `anyhow`. Decrypted values are wrapped in `secrecy::SecretString` and never logged. All encryption goes through the `age` crate — no custom crypto.
+
 ## License
 
-MIT
+MIT.


### PR DESCRIPTION
## Summary

Refreshes the root `README.md`. Previous version (2026-03-18) accurately described RevVault as a tool but didn't frame it as the canonical secret source-of-truth for the entire RevFleet — that's the load-bearing constraint downstream consumers care about.

What changed:

- Top blurb now leads with the fleet-wide secrets rule (every fleet secret lives here; one age identity gates everything; rotation = single store update; downstream systems re-read from the same source)
- New **Canonical paths** table covering current conventions: `revealui/dev/`, `revealui/prod/`, `revealui/prod/storage/r2/`, `revealcoin/`, `revforge/customers/`, `revdev/`, `credentials/<system>/`
- New "Downstream sync" feature line — GitHub Actions secrets + Vercel envelope mirroring via `revvault-vercel.toml`
- `--json` flag in CLI examples (fixes the silent-in-`$(...)` gotcha for shell scripts)
- `crates/core` architecture line extended to include `import` and `rotation` (matches current code)
- Workspace version annotation: `0.2.0` per fleet pre-1.0 convention
- Example CLI paths updated from `credentials/stripe/*` to the canonical `revealui/prod/stripe/*`
- Store-format tree refreshed to show the fleet path layout

## Test plan

- [ ] CI passes (cargo fmt, clippy, tests, frontend build)
- [ ] No changes to crates, frontend, or scripts — README-only PR
