### PR TITLE
feat(sync): add fly target to revvault sync (Railway->Fly secrets mirror)

### DIFF
--- a/crates/cli/src/commands/sync.rs
+++ b/crates/cli/src/commands/sync.rs
@@ -9,6 +9,7 @@ use clap::Args;
 use secrecy::ExposeSecret;
 use serde::{Deserialize, Serialize};
 
+use revvault_core::sync::fly::FlyClient;
 use revvault_core::sync::shape::{self, Shape};
 use revvault_core::sync::vercel::{VercelClient, VercelEnvVar};
 use revvault_core::{Config, PassageStore};
@@ -17,7 +18,7 @@ use revvault_core::{Config, PassageStore};
 
 #[derive(Args)]
 pub struct SyncArgs {
-    /// Target to sync with (currently only "vercel" is supported)
+    /// Target to sync with: "vercel" or "fly"
     pub target: String,
 
     /// Path to the sync manifest (default: revvault-vercel.toml)
@@ -28,7 +29,7 @@ pub struct SyncArgs {
     #[arg(long)]
     pub apply: bool,
 
-    /// Vercel API token (or set VERCEL_TOKEN env var)
+    /// API token for the target (or set VERCEL_TOKEN / FLY_API_TOKEN env var)
     #[arg(long)]
     pub token: Option<String>,
 }
@@ -125,6 +126,43 @@ fn default_targets() -> Vec<String> {
     ]
 }
 
+// ── Fly manifest schema ───────────────────────────────────────────────────────
+//
+// Fly secrets are app-scoped (no per-environment "targets") and the API never
+// returns secret *values* — only names + an opaque digest. So the Fly manifest
+// is app-centric and lists an explicit curated set of secrets (no prefix-scan:
+// we never want to push every secret under a prefix onto a worker app).
+
+#[derive(Debug, Deserialize)]
+struct FlyManifest {
+    /// Map of logical name → Fly app sync config (TOML `[fly-apps.<name>]`).
+    #[serde(default, rename = "fly-apps")]
+    fly_apps: HashMap<String, FlyAppSync>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FlyAppSync {
+    /// Fly app name (used as the GraphQL `appId`).
+    app: String,
+    /// Secret names this sync intentionally never touches.
+    #[serde(default)]
+    skip: Vec<String>,
+    /// Secret name → vault path (+ optional shape), reusing [`VarEntry`].
+    /// Every managed secret must be listed — there is no prefix fallback.
+    #[serde(default)]
+    vars: HashMap<String, VarEntry>,
+}
+
+impl FlyAppSync {
+    /// Resolve the vault path + declared shape for a Fly secret name, or
+    /// `None` when the name is not declared in `vars`.
+    fn vault_path_for(&self, var_name: &str) -> Option<(String, Shape)> {
+        self.vars
+            .get(var_name)
+            .map(|entry| (entry.path().to_string(), entry.shape()))
+    }
+}
+
 // ── Diff engine ─────────────────────────────────────────────────────────────
 
 #[derive(Debug, Serialize)]
@@ -179,10 +217,14 @@ fn append_audit_log(entry: &AuditEntry) -> anyhow::Result<()> {
 // ── Main runner ─────────────────────────────────────────────────────────────
 
 pub async fn run(args: SyncArgs, json_output: bool) -> anyhow::Result<()> {
-    if args.target != "vercel" {
-        bail!("Unknown sync target '{}'. Supported: vercel", args.target);
+    match args.target.as_str() {
+        "vercel" => run_vercel(args, json_output).await,
+        "fly" => run_fly(args, json_output).await,
+        other => bail!("Unknown sync target '{}'. Supported: vercel, fly", other),
     }
+}
 
+async fn run_vercel(args: SyncArgs, json_output: bool) -> anyhow::Result<()> {
     let token = args
         .token
         .or_else(|| std::env::var("VERCEL_TOKEN").ok())
@@ -200,6 +242,26 @@ pub async fn run(args: SyncArgs, json_output: bool) -> anyhow::Result<()> {
     let client = VercelClient::new(token, manifest.team_id.clone());
 
     push_mode(&store, &client, &manifest, args.apply, json_output).await
+}
+
+async fn run_fly(args: SyncArgs, json_output: bool) -> anyhow::Result<()> {
+    let token = args
+        .token
+        .or_else(|| std::env::var("FLY_API_TOKEN").ok())
+        .ok_or_else(|| {
+            anyhow::anyhow!("FLY_API_TOKEN not set. Pass --token or set FLY_API_TOKEN env var")
+        })?;
+
+    let manifest_content = fs::read_to_string(&args.manifest)
+        .with_context(|| format!("Cannot read manifest: {}", args.manifest.display()))?;
+    let manifest: FlyManifest =
+        toml::from_str(&manifest_content).context("Invalid Fly manifest TOML")?;
+
+    let config = Config::resolve()?;
+    let store = PassageStore::open(config)?;
+    let client = FlyClient::new(token);
+
+    push_mode_fly(&store, &client, &manifest, args.apply, json_output).await
 }
 
 // ── Push mode: sync vault to Vercel ─────────────────────────────────────────
@@ -527,6 +589,163 @@ async fn push_mode(
     Ok(())
 }
 
+// ── Push mode (Fly): batch vault → Fly setSecrets ────────────────────────────
+//
+// Fly hides secret values, so there is no value-equality MATCH: a present name
+// is an Update (re-set), an absent one an Add. All shape-valid secrets are
+// batched into ONE `setSecrets` call (= one Fly release). `replace_all=false`
+// means secrets not in the manifest are never deleted — orphans are surfaced
+// only, mirroring the Vercel client's no-delete policy.
+
+async fn push_mode_fly(
+    store: &PassageStore,
+    client: &FlyClient,
+    manifest: &FlyManifest,
+    apply: bool,
+    json_output: bool,
+) -> anyhow::Result<()> {
+    for (logical_name, app_cfg) in &manifest.fly_apps {
+        let remote = client.list_secret_names(&app_cfg.app).await?;
+        let remote_names: std::collections::HashSet<String> =
+            remote.into_iter().map(|s| s.name).collect();
+
+        let mut diff: Vec<DiffEntry> = Vec::new();
+        // (key, raw_value) pairs to push in one batched setSecrets on --apply.
+        let mut batch: Vec<(String, String)> = Vec::new();
+
+        for var_name in app_cfg.vars.keys() {
+            if app_cfg.skip.contains(var_name) {
+                diff.push(DiffEntry {
+                    key: var_name.clone(),
+                    action: DiffAction::Skip,
+                    reason: Some("in skip list".to_string()),
+                });
+                continue;
+            }
+
+            let (vault_path, declared_shape) = match app_cfg.vault_path_for(var_name) {
+                Some(v) => v,
+                None => continue, // unreachable: var_name came from vars.keys()
+            };
+
+            let vault_value = match store.get(&vault_path) {
+                Ok(s) => s,
+                Err(e) => {
+                    if !json_output {
+                        eprintln!(
+                            "  \x1b[31m✗\x1b[0m {} — cannot read vault path {}: {}",
+                            var_name, vault_path, e
+                        );
+                    }
+                    continue;
+                }
+            };
+            let raw_value = vault_value.expose_secret();
+
+            if let Some(v) = shape::check(raw_value, declared_shape).err() {
+                diff.push(DiffEntry {
+                    key: var_name.clone(),
+                    action: DiffAction::DropShape,
+                    reason: Some(format!("shape violation: {v}")),
+                });
+                continue;
+            }
+
+            diff.push(DiffEntry {
+                key: var_name.clone(),
+                action: if remote_names.contains(var_name) {
+                    DiffAction::Update
+                } else {
+                    DiffAction::Add
+                },
+                reason: None,
+            });
+            batch.push((var_name.clone(), raw_value.to_string()));
+        }
+
+        // Orphans: set on Fly but not in the manifest (never auto-deleted).
+        for name in &remote_names {
+            if app_cfg.skip.contains(name) || app_cfg.vars.contains_key(name) {
+                continue;
+            }
+            diff.push(DiffEntry {
+                key: name.clone(),
+                action: DiffAction::Orphan,
+                reason: Some("set on Fly but not in manifest".to_string()),
+            });
+        }
+
+        if json_output {
+            println!(
+                "{}",
+                serde_json::json!({
+                    "app": app_cfg.app,
+                    "logical": logical_name,
+                    "mode": "push-fly",
+                    "dry_run": !apply,
+                    "diff": diff,
+                })
+            );
+        } else {
+            println!(
+                "\n\x1b[1m{}\x1b[0m → Fly app \x1b[1m{}\x1b[0m (push{})",
+                logical_name,
+                app_cfg.app,
+                if apply { "" } else { " — dry-run" }
+            );
+            for entry in &diff {
+                let (symbol, color) = match entry.action {
+                    DiffAction::Add => ("+", "\x1b[32m"),
+                    DiffAction::Update => ("~", "\x1b[33m"),
+                    DiffAction::Match => ("=", "\x1b[90m"),
+                    DiffAction::Orphan => ("!", "\x1b[31m"),
+                    DiffAction::Skip => ("-", "\x1b[90m"),
+                    DiffAction::DropShape => ("✗", "\x1b[31m"),
+                };
+                let reason = entry
+                    .reason
+                    .as_deref()
+                    .map(|r| format!(" ({})", r))
+                    .unwrap_or_default();
+                println!("  {}{}\x1b[0m {}{}", color, symbol, entry.key, reason);
+            }
+        }
+
+        // Apply: one batched setSecrets call = one Fly release.
+        if apply {
+            if batch.is_empty() {
+                if !json_output {
+                    println!("  no secrets to set");
+                }
+            } else {
+                let result = client
+                    .set_secrets(&app_cfg.app, &batch, false)
+                    .await
+                    .with_context(|| format!("setSecrets failed for Fly app '{}'", app_cfg.app))?;
+                for (key, raw) in &batch {
+                    let _ = append_audit_log(&AuditEntry {
+                        timestamp: Utc::now().to_rfc3339(),
+                        action: "set-fly".to_string(),
+                        project: app_cfg.app.clone(),
+                        key: key.clone(),
+                        value_shape: shape::classify(raw),
+                        result: "ok".to_string(),
+                        error: None,
+                    });
+                }
+                if !json_output {
+                    match result.release_version {
+                        Some(v) => println!("  {} secrets set — Fly release v{}", batch.len(), v),
+                        None => println!("  {} secrets set", batch.len()),
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -686,5 +905,57 @@ mod tests {
     #[allow(dead_code)]
     fn project_string_only(vars: HashMap<String, String>) -> ProjectSync {
         project_with_string_vars(vars)
+    }
+
+    // ── Fly manifest ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn fly_manifest_parses_apps_and_vars() {
+        let toml_src = r#"
+            [fly-apps.revealui-worker]
+            app = "revealui-worker"
+
+            [fly-apps.revealui-worker.vars]
+            POSTGRES_URL = "revealui/prod/db/postgres-url"
+            ELECTRIC_SECRET = "revealui/prod/electric/secret"
+        "#;
+        let manifest: FlyManifest = toml::from_str(toml_src).unwrap();
+        let app = manifest.fly_apps.get("revealui-worker").unwrap();
+        assert_eq!(app.app, "revealui-worker");
+        assert_eq!(app.vars.len(), 2);
+        let (path, shape) = app.vault_path_for("POSTGRES_URL").unwrap();
+        assert_eq!(path, "revealui/prod/db/postgres-url");
+        assert_eq!(shape, Shape::Any);
+        assert!(app.vault_path_for("NOT_DECLARED").is_none());
+    }
+
+    #[test]
+    fn fly_manifest_supports_object_var_with_shape() {
+        let toml_src = r#"
+            [fly-apps.worker]
+            app = "revealui-worker"
+
+            [fly-apps.worker.vars]
+            POSTGRES_URL = { path = "revealui/prod/db/postgres-url", shape = "postgres-url" }
+        "#;
+        let manifest: FlyManifest = toml::from_str(toml_src).unwrap();
+        let app = manifest.fly_apps.get("worker").unwrap();
+        let (_, shape) = app.vault_path_for("POSTGRES_URL").unwrap();
+        assert_eq!(shape, Shape::PostgresUrl);
+    }
+
+    #[test]
+    fn fly_manifest_skip_list_parses() {
+        let toml_src = r#"
+            [fly-apps.worker]
+            app = "revealui-worker"
+            skip = ["NODE_ENV"]
+
+            [fly-apps.worker.vars]
+            FOO = "revealui/prod/foo"
+        "#;
+        let manifest: FlyManifest = toml::from_str(toml_src).unwrap();
+        let app = manifest.fly_apps.get("worker").unwrap();
+        assert!(app.skip.contains(&"NODE_ENV".to_string()));
     }
 }

--- a/crates/core/src/sync/fly.rs
+++ b/crates/core/src/sync/fly.rs
@@ -1,0 +1,372 @@
+//! Fly.io secrets sync client.
+//!
+//! Consumed by `revvault sync fly` (cli/src/commands/sync.rs) to push vault
+//! secrets onto a Fly app. Mirrors [`super::vercel::VercelClient`] (transport +
+//! 429 retry + DTOs); manifest deserialization stays in the cli crate.
+//!
+//! # Why this differs from the Vercel client
+//!
+//! Fly's API is **write-only for secret values**. The `app.secrets` query
+//! returns only secret *names* + an opaque `digest` — never the value. So
+//! unlike the Vercel flow, the sync diff cannot do value-equality MATCH
+//! detection; it can only tell Add (name absent) from Set (name present).
+//! [`FlyClient::set_secrets`] batches every managed secret into one
+//! `setSecrets` mutation (= one Fly release) and passes `replaceAll: false`
+//! so secrets not in the manifest are never deleted.
+//!
+//! # Retry
+//!
+//! [`FlyClient::send_retrying`] retries `429 Too Many Requests` with backoffs
+//! of 100ms / 500ms / 2000ms — identical policy to the Vercel client. Other
+//! non-2xx statuses surface immediately. GraphQL-level errors (HTTP 200 with a
+//! non-empty `errors` array) are also surfaced as `Err`.
+//!
+//! # Test injection
+//!
+//! [`FlyClient::with_base_url`] swaps the default `https://api.fly.io/graphql`
+//! endpoint for a mockito server URL so the request shape + retry can be
+//! exercised without network access or a real Fly token.
+
+use std::time::Duration;
+
+use anyhow::{bail, Context};
+use serde::{Deserialize, Serialize};
+
+const DEFAULT_BASE_URL: &str = "https://api.fly.io/graphql";
+const RETRY_BACKOFFS_MS: [u64; 3] = [100, 500, 2000];
+
+// ── Fly API types ─────────────────────────────────────────────────────────
+
+/// A secret as reported by Fly's `app.secrets` query — name + opaque digest.
+/// Never carries a value (Fly does not expose secret values via the API).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FlySecret {
+    pub name: String,
+    pub digest: Option<String>,
+}
+
+/// Outcome of a `setSecrets` mutation — the release it triggered, if any.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SetSecretsResult {
+    pub release_id: Option<String>,
+    pub release_version: Option<i64>,
+}
+
+// ── Client ────────────────────────────────────────────────────────────────
+
+/// Thin async client over Fly's GraphQL secrets API.
+///
+/// Constructed via [`FlyClient::new`] for production use; tests use
+/// [`FlyClient::with_base_url`] to point requests at a mock server.
+pub struct FlyClient {
+    token: String,
+    base: String,
+    client: reqwest::Client,
+}
+
+impl FlyClient {
+    /// Construct a client with the production Fly GraphQL endpoint. `token` is
+    /// a Fly API token (org token or app deploy token) — passed as a bearer.
+    pub fn new(token: String) -> Self {
+        Self {
+            token,
+            base: DEFAULT_BASE_URL.to_string(),
+            client: reqwest::Client::new(),
+        }
+    }
+
+    /// Override the GraphQL endpoint — used by tests to point the client at a
+    /// mockito server.
+    pub fn with_base_url(mut self, base: impl Into<String>) -> Self {
+        self.base = base.into();
+        self
+    }
+
+    /// Send a request, retrying up to 3 times on `429 Too Many Requests` with
+    /// backoffs of 100ms / 500ms / 2000ms. Builder must be cloneable; a JSON
+    /// body (the only kind this client sends) is fine.
+    async fn send_retrying(
+        &self,
+        builder: reqwest::RequestBuilder,
+    ) -> anyhow::Result<reqwest::Response> {
+        let mut attempt = 0usize;
+        loop {
+            let cloned = builder
+                .try_clone()
+                .expect("FlyClient request must be cloneable for retry-on-429");
+            let resp = cloned.send().await.context("Failed to reach Fly API")?;
+            if resp.status() == reqwest::StatusCode::TOO_MANY_REQUESTS
+                && attempt < RETRY_BACKOFFS_MS.len()
+            {
+                tokio::time::sleep(Duration::from_millis(RETRY_BACKOFFS_MS[attempt])).await;
+                attempt += 1;
+                continue;
+            }
+            return Ok(resp);
+        }
+    }
+
+    /// POST a GraphQL operation and return the parsed JSON `data`-bearing body.
+    /// Surfaces transport errors, non-2xx HTTP, and GraphQL `errors` as `Err`.
+    async fn graphql(
+        &self,
+        query: &str,
+        variables: serde_json::Value,
+    ) -> anyhow::Result<serde_json::Value> {
+        let body = serde_json::json!({ "query": query, "variables": variables });
+        let req = self
+            .client
+            .post(&self.base)
+            .bearer_auth(&self.token)
+            .json(&body);
+        let resp = self.send_retrying(req).await?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            bail!("Fly GraphQL returned {}: {}", status, text);
+        }
+
+        let value: serde_json::Value = resp.json().await.context("parsing Fly GraphQL JSON")?;
+        if let Some(errors) = value.get("errors") {
+            if errors.as_array().map(|a| !a.is_empty()).unwrap_or(false) {
+                bail!("Fly GraphQL errors: {}", errors);
+            }
+        }
+        Ok(value)
+    }
+
+    /// List the NAMES (+ opaque digests) of secrets set on a Fly app. Returns
+    /// an empty vec when the app has no secrets; errors when the app is not
+    /// found (wrong name or insufficient token scope).
+    pub async fn list_secret_names(&self, app_name: &str) -> anyhow::Result<Vec<FlySecret>> {
+        let query = r#"query($name: String!) { app(name: $name) { secrets { name digest } } }"#;
+        let value = self
+            .graphql(query, serde_json::json!({ "name": app_name }))
+            .await?;
+
+        #[derive(Deserialize)]
+        struct SecretNode {
+            name: String,
+            digest: Option<String>,
+        }
+        #[derive(Deserialize)]
+        struct AppNode {
+            secrets: Vec<SecretNode>,
+        }
+        #[derive(Deserialize)]
+        struct Data {
+            app: Option<AppNode>,
+        }
+
+        let data: Data = serde_json::from_value(
+            value
+                .get("data")
+                .cloned()
+                .unwrap_or(serde_json::Value::Null),
+        )
+        .context("unexpected Fly app.secrets response shape")?;
+
+        let app = data.app.ok_or_else(|| {
+            anyhow::anyhow!(
+                "Fly app '{}' not found (check the app name and that the token has access)",
+                app_name
+            )
+        })?;
+
+        Ok(app
+            .secrets
+            .into_iter()
+            .map(|s| FlySecret {
+                name: s.name,
+                digest: s.digest,
+            })
+            .collect())
+    }
+
+    /// Set (create or update) secrets on a Fly app in one batched mutation,
+    /// which triggers a single release. `replace_all = false` leaves secrets
+    /// not in the batch untouched (no deletion) — orphan cleanup is never
+    /// automatic, mirroring the Vercel client's no-delete policy.
+    pub async fn set_secrets(
+        &self,
+        app_name: &str,
+        secrets: &[(String, String)],
+        replace_all: bool,
+    ) -> anyhow::Result<SetSecretsResult> {
+        let mutation = r#"mutation($input: SetSecretsInput!) { setSecrets(input: $input) { release { id version } } }"#;
+        let secret_inputs: Vec<serde_json::Value> = secrets
+            .iter()
+            .map(|(k, v)| serde_json::json!({ "key": k, "value": v }))
+            .collect();
+        let variables = serde_json::json!({
+            "input": {
+                "appId": app_name,
+                "secrets": secret_inputs,
+                "replaceAll": replace_all,
+            }
+        });
+        let value = self.graphql(mutation, variables).await?;
+
+        let release = value
+            .pointer("/data/setSecrets/release")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null);
+        Ok(SetSecretsResult {
+            release_id: release.get("id").and_then(|v| v.as_str()).map(String::from),
+            release_version: release.get("version").and_then(serde_json::Value::as_i64),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn list_secret_names_parses_names_and_digests() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/")
+            .match_header("authorization", "Bearer tok")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"data":{"app":{"secrets":[{"name":"POSTGRES_URL","digest":"abc"},{"name":"REVEALUI_SECRET","digest":null}]}}}"#,
+            )
+            .create_async()
+            .await;
+
+        let client = FlyClient::new("tok".into()).with_base_url(server.url());
+        let secrets = client.list_secret_names("revealui-worker").await.unwrap();
+
+        assert_eq!(secrets.len(), 2);
+        assert_eq!(secrets[0].name, "POSTGRES_URL");
+        assert_eq!(secrets[0].digest.as_deref(), Some("abc"));
+        assert_eq!(secrets[1].name, "REVEALUI_SECRET");
+        assert_eq!(secrets[1].digest, None);
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn list_secret_names_empty_when_no_secrets() {
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("POST", "/")
+            .with_status(200)
+            .with_body(r#"{"data":{"app":{"secrets":[]}}}"#)
+            .create_async()
+            .await;
+
+        let client = FlyClient::new("tok".into()).with_base_url(server.url());
+        let secrets = client.list_secret_names("revealui-worker").await.unwrap();
+        assert!(secrets.is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_secret_names_errors_when_app_missing() {
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("POST", "/")
+            .with_status(200)
+            .with_body(r#"{"data":{"app":null}}"#)
+            .create_async()
+            .await;
+
+        let client = FlyClient::new("tok".into()).with_base_url(server.url());
+        let err = client.list_secret_names("nope").await.unwrap_err();
+        assert!(format!("{err}").contains("not found"));
+    }
+
+    #[tokio::test]
+    async fn set_secrets_sends_batched_input_and_parses_release() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/")
+            .match_header("authorization", "Bearer tok")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "variables": {
+                    "input": {
+                        "appId": "revealui-worker",
+                        "replaceAll": false,
+                        "secrets": [ { "key": "POSTGRES_URL", "value": "postgres://x" } ],
+                    }
+                }
+            })))
+            .with_status(200)
+            .with_body(r#"{"data":{"setSecrets":{"release":{"id":"rel_1","version":7}}}}"#)
+            .create_async()
+            .await;
+
+        let client = FlyClient::new("tok".into()).with_base_url(server.url());
+        let res = client
+            .set_secrets(
+                "revealui-worker",
+                &[("POSTGRES_URL".to_string(), "postgres://x".to_string())],
+                false,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(res.release_id.as_deref(), Some("rel_1"));
+        assert_eq!(res.release_version, Some(7));
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn graphql_errors_surface_as_err() {
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("POST", "/")
+            .with_status(200)
+            .with_body(r#"{"errors":[{"message":"Unauthorized"}]}"#)
+            .create_async()
+            .await;
+
+        let client = FlyClient::new("tok".into()).with_base_url(server.url());
+        let err = client.list_secret_names("x").await.unwrap_err();
+        assert!(format!("{err}").contains("GraphQL errors"));
+    }
+
+    #[tokio::test]
+    async fn retries_on_429_then_succeeds() {
+        let mut server = mockito::Server::new_async().await;
+        let m429 = server
+            .mock("POST", "/")
+            .with_status(429)
+            .with_body("{}")
+            .expect(2)
+            .create_async()
+            .await;
+        let m200 = server
+            .mock("POST", "/")
+            .with_status(200)
+            .with_body(r#"{"data":{"app":{"secrets":[]}}}"#)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let client = FlyClient::new("tok".into()).with_base_url(server.url());
+        client.list_secret_names("p").await.unwrap();
+
+        m429.assert_async().await;
+        m200.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn non_429_error_surfaces_without_retry() {
+        let mut server = mockito::Server::new_async().await;
+        let m = server
+            .mock("POST", "/")
+            .with_status(500)
+            .with_body("boom")
+            .expect(1)
+            .create_async()
+            .await;
+
+        let client = FlyClient::new("tok".into()).with_base_url(server.url());
+        let err = client.list_secret_names("p").await.unwrap_err();
+        assert!(format!("{err}").contains("500"));
+        m.assert_async().await;
+    }
+}

--- a/crates/core/src/sync/fly.rs
+++ b/crates/core/src/sync/fly.rs
@@ -16,8 +16,8 @@
 //!
 //! # Retry
 //!
-//! [`FlyClient::send_retrying`] retries `429 Too Many Requests` with backoffs
-//! of 100ms / 500ms / 2000ms — identical policy to the Vercel client. Other
+//! The transport retries `429 Too Many Requests` with backoffs of 100ms /
+//! 500ms / 2000ms — identical policy to the Vercel client. Other
 //! non-2xx statuses surface immediately. GraphQL-level errors (HTTP 200 with a
 //! non-empty `errors` array) are also surfaced as `Err`.
 //!

--- a/crates/core/src/sync/mod.rs
+++ b/crates/core/src/sync/mod.rs
@@ -7,8 +7,10 @@
 //! `rotation.toml`). Both flows share the [`vercel::VercelClient`]
 //! transport in this module.
 
+pub mod fly;
 pub mod shape;
 pub mod vercel;
 
+pub use fly::{FlyClient, FlySecret};
 pub use shape::{Shape, ShapeViolation};
 pub use vercel::{VercelClient, VercelEnvVar};


### PR DESCRIPTION
## What

Adds a `fly` target to `revvault sync` — `revvault sync fly --manifest scripts/sync/revvault-fly.toml [--apply] [--token]` — the Fly.io counterpart to the existing `sync vercel`. Phase 4 of the drop-railway → Fly migration (tracking: an internal repo).

## Why

The lane plan originally assumed `revvault sync` could be pointed at Fly via a `[providers.fly]` manifest block. In reality `sync` was Vercel-only (it `bail!`ed on any other target), `[providers.*]` belongs to `revvault rotate` (not `sync`), and Fly sets secrets through a completely different API. So the mirror needs a real `fly` target.

## Design (mirrors `sync vercel`, adapts to Fly)

- **`crates/core/src/sync/fly.rs`** — `FlyClient` over Fly's GraphQL API (`https://api.fly.io/graphql`): `setSecrets` mutation + `app { secrets { name digest } }` query, bearer token, 429 retry (100/500/2000ms), `with_base_url()` for mockito tests. Direct mirror of `VercelClient`.
- **`crates/cli/src/commands/sync.rs`** — app-centric `FlyManifest` (`[fly-apps.<name>]` with explicit `vars`; no prefix-scan, since a worker's secret set is a curated subset). Reuses `VarEntry` + `shape::check` + the audit log. `push_mode_fly` batches all shape-valid secrets into **one** `setSecrets` call (one Fly release), `replaceAll: false`.
- **Key difference from Vercel:** Fly's API never returns secret *values* (only names + opaque digest), so there is no value-equality `MATCH` — a present name is Set/Update, an absent one Add. Orphans (on Fly, not in the manifest) are surfaced, never deleted (same no-delete policy as the Vercel client).

## Checks (verified locally)

- `cargo test -p revvault-core -p revvault-cli sync` → 52 core + 11 cli sync tests pass (6 new `FlyClient` mockito tests; 3 new `FlyManifest` parse tests).
- `cargo fmt --check` clean; `cargo clippy --all-targets` exit 0.

## Owner-gated / separate follow-ups (NOT in this PR)

- The consuming manifest `scripts/sync/revvault-fly.toml` + the `docs/deployment/fly.md` wording fix (it currently references an aspirational `revvault-sync`) live in a **separate revealui PR**.
- A live `--apply` needs a Fly API token vaulted at `revealui/prod/fly/api-token` and the target Fly app (`revealui-worker`) to exist (lane Phase 3). The unit tests need neither.
- GraphQL request shapes follow the documented `setSecrets`/`app.secrets` schema; validating against a live token is part of the owner-gated apply step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
