### PR TITLE
fix(ci,docs): resolve codex P1 review findings

### DIFF
--- a/.github/workflows/promotion-gate.yml
+++ b/.github/workflows/promotion-gate.yml
@@ -20,10 +20,20 @@ jobs:
   promotion-gate:
     runs-on: ubuntu-latest
     steps:
-      - name: Verify head branch is 'test'
+      - name: Verify head branch is 'test' from the canonical repo
         env:
           HEAD_REF: ${{ github.head_ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
         run: |
+          # A fork can name a branch 'test' and open a PR to main; head_ref alone
+          # ('test') would pass, and the ancestry check below only proves the fork
+          # branch contains main — not that the changes were promoted through THIS
+          # repo's test branch. Require the PR to originate from this repository.
+          if [ "$HEAD_REPO" != "$BASE_REPO" ]; then
+            echo "::error title=Cross-repo promotion::Promotion PRs to main must come from '$BASE_REPO' (this repo's 'test' branch), not a fork. Got head repo: '$HEAD_REPO'."
+            exit 1
+          fi
           if [ "$HEAD_REF" != "test" ]; then
             echo "::error title=Wrong head branch::Promotion PRs to main must come from 'test'. Got: '$HEAD_REF'."
             echo ""

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ revvault sync fly --manifest fly-secrets.toml --apply
 revvault doctor
 
 # Migrate plaintext secret files into the vault
-revvault migrate <source>
+revvault migrate --plaintext-dir <source>
 
 # Delete
 revvault delete revealui/prod/stripe/secret-key


### PR DESCRIPTION
## Summary

Resolves the verifiable P1 `chatgpt-codex-connector` findings on revvault, validated against current `test`.

## Fixed

- **Promotion gate trusted the branch name alone** (codex on #56): a fork could open a PR to `main` from a branch named `test` and pass. The gate now also requires `head.repo == this repository`.
- **README migrate example was broken** (codex on #73): `migrate` takes `--plaintext-dir <dir>` (clap `#[arg(long)]` in `crates/cli/src/commands/migrate.rs`), not a positional source; `revvault migrate <source>` fails. Fixed the Quick Start example.

## Already fixed (confirmed stale)

- **#67 (gitleaks tarball integrity)**: `ci.yml` already pins `GITLEAKS_SHA256` and runs `sha256sum -c` before install.
- **#72 (backflow `@main` pin)**: already pinned to an immutable `.github` SHA.

## Deferred — Rust correctness (needs native `cargo test`)

Four P1s are subtle Rust correctness bugs in a secrets tool. Per verify-before-claiming and the RAM-constrained workstation (no reliable local `cargo build`/`test`), these go to a dedicated WSL-terminal session rather than ship CI-verified-only:
- **#2** (`sync.rs`): `--pull` may import non-decrypted Vercel env values.
- **#18** (`neon.rs`): `connection_uri` built without `branch_id` after rotation.
- **#47** (`sync.rs`): decrypted match check not scoped to the selected target.
- **#63** (`sync.rs`): missing `fly-apps` parses to a silent no-op success.

Also **#60** (pipefail SIGPIPE on `git log … | head -20`) now lives in the shared `RevealUIStudio/.github` backflow-reusable workflow — folded into the coordinated `.github` change.

## Verification

YAML parse of the workflow; the README change is a one-line correction matching `migrate.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
