### PR TITLE
chore(release): promote test to main (revvault 0.3.0 sync fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 All notable changes to revvault are documented here. Follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) conventions; versions follow [SemVer 2.0.0](https://semver.org/).
 
+## [0.3.0] — 2026-06-11
+
+### Fixed
+
+- **`sync vercel --apply` no longer downgrades Vercel `sensitive` env vars to
+  `encrypted` on re-create.** `create_env_var` previously hardcoded
+  `type=encrypted`; re-creating a var that existed as `sensitive` (after an
+  external delete, or when the surviving rows sit on non-synced targets)
+  silently made the credential revealable in the Vercel UI — observed
+  2026-06-10 when a sync apply re-created Stripe + signing secrets as
+  `encrypted`. Creates now preserve sensitivity: if any remote row with the
+  same key is `sensitive`, the new row is created `sensitive`. Updates were
+  already safe (the value-only PATCH never touches type).
+
+### Added
+
+- **`sensitive = true` per-var manifest marker.** `[projects.<slug>.vars]`
+  inline tables accept `sensitive = true` to request Vercel type `sensitive`
+  on create: `KEY = { path = "...", sensitive = true }`. The inline table's
+  `shape` is now optional (defaults to `any`). Unknown keys in a var entry
+  are rejected at parse time so a typo'd marker fails loudly instead of
+  silently leaving a credential downgradable. (`revvault doctor` tolerates
+  and ignores the marker — it validates vault values, not Vercel types.)
+- **`sensitive` flag on rotation sync targets.** `[[providers.<name>.sync.vercel.env_vars]]`
+  entries accept `sensitive = true` so the rotation chain's create-fallback
+  also requests type `sensitive`.
+- **Type visibility.** Push diffs annotate creates that will request
+  `sensitive` and warn on type drift (manifest wants `sensitive` but the
+  remote row is not — updates preserve type, so flipping requires delete +
+  re-create). The JSONL audit log records `var_type` on create entries.
+- **Loud type rejection.** If Vercel rejects the requested type, the create
+  fails naming that type — there is no silent fallback to `encrypted`.
+
+### Changed
+
+- The sync audit log now writes to the `.revvault/` directory of the store
+  the sync actually used, instead of re-resolving configuration.
+
 ## [0.2.0] — 2026-05-14
 
 ### Breaking changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4505,7 +4505,7 @@ dependencies = [
 
 [[package]]
 name = "revvault-cli"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "age",
  "anyhow",
@@ -4537,7 +4537,7 @@ dependencies = [
 
 [[package]]
 name = "revvault-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "age",
  "anyhow",
@@ -4562,7 +4562,7 @@ dependencies = [
 
 [[package]]
 name = "revvault-tauri"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,14 +3,14 @@ resolver = "2"
 members = ["crates/core", "crates/cli", "crates/tauri-app"]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT"
 authors = ["Joshua Vaughn <joshua.v.dev@gmail.com>"]
 
 [workspace.dependencies]
-revvault-core = { version = "0.2", path = "crates/core" }
+revvault-core = { version = "0.3", path = "crates/core" }
 age = { version = "0.11", features = ["armor"] }
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }

--- a/crates/cli/src/commands/doctor.rs
+++ b/crates/cli/src/commands/doctor.rs
@@ -51,7 +51,20 @@ struct ProjectSync {
 #[serde(untagged)]
 enum VarEntry {
     Path(String),
-    Object { path: String, shape: Shape },
+    /// Inline table. `shape` is optional (defaults to `any`); keys the
+    /// full sync schema understands but doctor does not act on (e.g.
+    /// `sensitive`) are tolerated and ignored — doctor is a vault-only
+    /// health check and never writes to Vercel, so env-var sensitivity
+    /// does not change what it validates.
+    Object {
+        path: String,
+        #[serde(default = "default_shape")]
+        shape: Shape,
+    },
+}
+
+fn default_shape() -> Shape {
+    Shape::Any
 }
 
 impl VarEntry {
@@ -315,6 +328,28 @@ mod tests {
                 assert!(result.is_ok(), "expected pass for {var_name}: {result:?}");
             }
         }
+    }
+
+    #[test]
+    fn doctor_parses_sensitive_marker_and_optional_shape() {
+        // The sync schema's `sensitive = true` marker (with or without a
+        // declared shape) must not break doctor's manifest subset.
+        let manifest_src = r#"
+            [projects.api]
+            project_id = "prj_test"
+            vault_prefix = "revealui/prod"
+
+            [projects.api.vars]
+            STRIPE_SECRET_KEY = { path = "revealui/prod/stripe/secret-key", shape = "stripe-key-live-only", sensitive = true }
+            REVEALUI_SECRET = { path = "revealui/prod/secret", sensitive = true }
+        "#;
+        let parsed: SyncManifest = toml::from_str(manifest_src).unwrap();
+        let api = parsed.projects.get("api").unwrap();
+        assert_eq!(
+            api.vars.get("STRIPE_SECRET_KEY").unwrap().shape(),
+            Shape::StripeKeyLiveOnly
+        );
+        assert_eq!(api.vars.get("REVEALUI_SECRET").unwrap().shape(), Shape::Any);
     }
 
     #[test]

--- a/crates/cli/src/commands/sync.rs
+++ b/crates/cli/src/commands/sync.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 
 use revvault_core::sync::fly::FlyClient;
 use revvault_core::sync::shape::{self, Shape};
-use revvault_core::sync::vercel::{VercelClient, VercelEnvVar};
+use revvault_core::sync::vercel::{EnvVarType, VercelClient, VercelEnvVar};
 use revvault_core::{Config, PassageStore};
 
 // ── CLI args ────────────────────────────────────────────────────────────────
@@ -57,21 +57,32 @@ struct ProjectSync {
     /// Skip these env var names (integration-managed, etc.)
     #[serde(default)]
     skip: Vec<String>,
-    /// Per-var path + optional shape overrides.
+    /// Per-var path + optional shape / sensitivity overrides.
     ///
     /// Supports two TOML forms for backwards compatibility:
     ///
-    /// Bare string (path only, shape defaults to `any`):
+    /// Bare string (path only; shape defaults to `any`, sensitive to `false`):
     /// ```toml
     /// [projects.api.vars]
     /// POSTGRES_URL = "revealui/prod/db/postgres-url"
     /// ```
     ///
-    /// Inline table (path + explicit shape):
+    /// Inline table (path + optional `shape` + optional `sensitive`):
     /// ```toml
     /// [projects.api.vars]
-    /// POSTGRES_URL = { path = "revealui/prod/db/postgres-url", shape = "postgres-url" }
+    /// POSTGRES_URL      = { path = "revealui/prod/db/postgres-url", shape = "postgres-url" }
+    /// STRIPE_SECRET_KEY = { path = "revealui/prod/stripe/secret-key", shape = "stripe-key-live-only", sensitive = true }
     /// ```
+    ///
+    /// `sensitive = true` requests Vercel type `sensitive` when this var is
+    /// CREATED: the plaintext is never revealable in the Vercel UI or API
+    /// after write. Use it for credentials (Stripe keys, webhook secrets,
+    /// signing/JWT secrets). Updates PATCH value-only and never change an
+    /// existing row's type, so flipping an existing `encrypted` row still
+    /// requires delete + re-create (the diff flags that drift). Independent
+    /// of the marker, a create also requests `sensitive` whenever any
+    /// existing remote row with the same key is `sensitive` — sensitivity
+    /// is preserved, never silently downgraded.
     #[serde(default)]
     vars: HashMap<String, VarEntry>,
 }
@@ -79,29 +90,58 @@ struct ProjectSync {
 /// A per-var entry in `[projects.<slug>.vars]`.
 ///
 /// `#[serde(untagged)]` makes TOML bare strings parse as `Path(String)`
-/// while inline tables parse as `Object { path, shape }`. Existing manifests
-/// that use bare strings keep working unchanged.
+/// while inline tables parse as `VarObject`. Existing manifests that use
+/// bare strings keep working unchanged.
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]
 enum VarEntry {
-    /// Bare string — path only; shape defaults to `Shape::Any`.
+    /// Bare string — path only; shape defaults to `Shape::Any`, sensitive
+    /// to `false`.
     Path(String),
-    /// Inline table — path + explicit shape constraint.
-    Object { path: String, shape: Shape },
+    /// Inline table — path + optional shape + optional sensitive marker.
+    Object(VarObject),
+}
+
+/// Inline-table form of a var entry: `{ path = "...", shape = "...",
+/// sensitive = true }`. `shape` defaults to `any`; `sensitive` defaults to
+/// `false`.
+///
+/// Unknown keys are rejected so a typo'd `sensitive` marker fails the
+/// parse loudly instead of silently leaving a credential downgradable.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct VarObject {
+    path: String,
+    #[serde(default = "default_shape")]
+    shape: Shape,
+    #[serde(default)]
+    sensitive: bool,
+}
+
+fn default_shape() -> Shape {
+    Shape::Any
 }
 
 impl VarEntry {
     fn path(&self) -> &str {
         match self {
             Self::Path(p) => p,
-            Self::Object { path, .. } => path,
+            Self::Object(o) => &o.path,
         }
     }
 
     fn shape(&self) -> Shape {
         match self {
             Self::Path(_) => Shape::Any,
-            Self::Object { shape, .. } => *shape,
+            Self::Object(o) => o.shape,
+        }
+    }
+
+    /// True when the inline table sets `sensitive = true`.
+    fn sensitive(&self) -> bool {
+        match self {
+            Self::Path(_) => false,
+            Self::Object(o) => o.sensitive,
         }
     }
 }
@@ -115,6 +155,11 @@ impl ProjectSync {
             Some(entry) => (entry.path().to_string(), entry.shape()),
             None => (format!("{}/{}", self.vault_prefix, var_name), Shape::Any),
         }
+    }
+
+    /// True when the manifest marks this var `sensitive = true`.
+    fn sensitive_for(&self, var_name: &str) -> bool {
+        self.vars.get(var_name).is_some_and(|e| e.sensitive())
     }
 }
 
@@ -196,13 +241,18 @@ struct AuditEntry {
     value_shape: String,
     /// "ok" | "failed"
     result: String,
+    /// Vercel env-var type requested on create (`encrypted` | `sensitive`).
+    /// `None` for non-create actions.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    var_type: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     error: Option<String>,
 }
 
-fn append_audit_log(entry: &AuditEntry) -> anyhow::Result<()> {
-    let config = Config::resolve()?;
-    let log_path = PathBuf::from(&config.store_dir).join(".revvault/rotation-log.jsonl");
+/// Append one JSONL row to the audit log inside the synced store's
+/// `.revvault/` directory.
+fn append_audit_log(store: &PassageStore, entry: &AuditEntry) -> anyhow::Result<()> {
+    let log_path = store.store_dir().join(".revvault/rotation-log.jsonl");
     if let Some(parent) = log_path.parent() {
         fs::create_dir_all(parent)?;
     }
@@ -284,6 +334,32 @@ fn validate_fly_manifest(manifest: &FlyManifest, path: &std::path::Path) -> anyh
 
 // ── Push mode: sync vault to Vercel ─────────────────────────────────────────
 
+/// Vercel type for a CREATE. `sensitive` is one-way: requested by the
+/// manifest marker or preserved from any existing remote row of the same
+/// key (a credential that is `sensitive` anywhere must never be re-created
+/// as a revealable type). There is no downgrade path.
+fn create_type_for(manifest_sensitive: bool, remote_sensitive: bool) -> EnvVarType {
+    if manifest_sensitive || remote_sensitive {
+        EnvVarType::Sensitive
+    } else {
+        EnvVarType::Encrypted
+    }
+}
+
+/// Diff annotation when the manifest wants `sensitive` but the remote row
+/// has some other type. Updates PATCH value-only — the type is preserved,
+/// never changed — so this drift survives every sync and needs a manual
+/// delete + re-create to resolve. `None` when there is no drift.
+fn type_drift_reason(manifest_sensitive: bool, remote_type: Option<&str>) -> Option<String> {
+    if !manifest_sensitive || remote_type == Some("sensitive") {
+        return None;
+    }
+    Some(format!(
+        "type drift: manifest wants sensitive, remote is {} — updates preserve type; delete + re-create to flip",
+        remote_type.unwrap_or("unknown")
+    ))
+}
+
 async fn push_mode(
     store: &PassageStore,
     client: &VercelClient,
@@ -321,6 +397,16 @@ async fn push_mode(
             .iter()
             .filter(|v| project_cfg.targets.iter().any(|t| v.target.contains(t)))
             .map(|v| (v.key.clone(), v))
+            .collect();
+
+        // Remote rows of ANY target that are Vercel type `sensitive`, by
+        // key. Deliberately NOT filtered by the synced targets: when the
+        // only surviving rows for a credential sit on other targets, a
+        // create on the synced target must still come back `sensitive`.
+        let remote_sensitive: std::collections::HashSet<String> = remote_vars
+            .iter()
+            .filter(|v| v.is_sensitive())
+            .map(|v| v.key.clone())
             .collect();
 
         // Build the union of vars to sync: explicit overrides + everything
@@ -383,7 +469,13 @@ async fn push_mode(
                 continue;
             }
 
-            if remote_map.contains_key(var_name) {
+            if let Some(remote) = remote_map.get(var_name) {
+                // Surface (but never auto-fix) manifest-vs-remote type drift.
+                let drift = type_drift_reason(
+                    project_cfg.sensitive_for(var_name),
+                    remote.var_type.as_deref(),
+                );
+
                 // Check for MATCH: if decrypted remote value equals vault value, skip the write.
                 let is_match = remote_decrypted_map
                     .as_ref()
@@ -395,20 +487,27 @@ async fn push_mode(
                     diff.push(DiffEntry {
                         key: var_name.clone(),
                         action: DiffAction::Match,
-                        reason: None,
+                        reason: drift,
                     });
                 } else {
                     diff.push(DiffEntry {
                         key: var_name.clone(),
                         action: DiffAction::Update,
-                        reason: None,
+                        reason: drift,
                     });
                 }
             } else {
+                let reason = match create_type_for(
+                    project_cfg.sensitive_for(var_name),
+                    remote_sensitive.contains(var_name),
+                ) {
+                    EnvVarType::Sensitive => Some("create as type=sensitive".to_string()),
+                    EnvVarType::Encrypted => None,
+                };
                 diff.push(DiffEntry {
                     key: var_name.clone(),
                     action: DiffAction::Add,
-                    reason: None,
+                    reason,
                 });
             }
         }
@@ -479,50 +578,67 @@ async fn push_mode(
 
                         // Shape guard (should already be DROP'd in diff, but be defensive)
                         if let Err(v) = shape::check(raw, declared_shape) {
-                            let _ = append_audit_log(&AuditEntry {
-                                timestamp: Utc::now().to_rfc3339(),
-                                action: "drop-shape".to_string(),
-                                project: project_name.clone(),
-                                key: entry.key.clone(),
-                                value_shape: shape::classify(raw),
-                                result: "failed".to_string(),
-                                error: Some(v.to_string()),
-                            });
+                            let _ = append_audit_log(
+                                store,
+                                &AuditEntry {
+                                    timestamp: Utc::now().to_rfc3339(),
+                                    action: "drop-shape".to_string(),
+                                    project: project_name.clone(),
+                                    key: entry.key.clone(),
+                                    value_shape: shape::classify(raw),
+                                    result: "failed".to_string(),
+                                    var_type: None,
+                                    error: Some(v.to_string()),
+                                },
+                            );
                             continue;
                         }
 
+                        let var_type = create_type_for(
+                            project_cfg.sensitive_for(&entry.key),
+                            remote_sensitive.contains(&entry.key),
+                        );
                         client
                             .create_env_var(
                                 &project_cfg.project_id,
                                 &entry.key,
                                 raw,
                                 &project_cfg.targets,
+                                var_type,
                             )
                             .await?;
-                        let _ = append_audit_log(&AuditEntry {
-                            timestamp: Utc::now().to_rfc3339(),
-                            action: "create".to_string(),
-                            project: project_name.clone(),
-                            key: entry.key.clone(),
-                            value_shape: shape::classify(raw),
-                            result: "ok".to_string(),
-                            error: None,
-                        });
+                        let _ = append_audit_log(
+                            store,
+                            &AuditEntry {
+                                timestamp: Utc::now().to_rfc3339(),
+                                action: "create".to_string(),
+                                project: project_name.clone(),
+                                key: entry.key.clone(),
+                                value_shape: shape::classify(raw),
+                                result: "ok".to_string(),
+                                var_type: Some(var_type.as_str().to_string()),
+                                error: None,
+                            },
+                        );
                     }
                     DiffAction::Update => {
                         let secret = store.get(&vault_path)?;
                         let raw = secret.expose_secret();
 
                         if let Err(v) = shape::check(raw, declared_shape) {
-                            let _ = append_audit_log(&AuditEntry {
-                                timestamp: Utc::now().to_rfc3339(),
-                                action: "drop-shape".to_string(),
-                                project: project_name.clone(),
-                                key: entry.key.clone(),
-                                value_shape: shape::classify(raw),
-                                result: "failed".to_string(),
-                                error: Some(v.to_string()),
-                            });
+                            let _ = append_audit_log(
+                                store,
+                                &AuditEntry {
+                                    timestamp: Utc::now().to_rfc3339(),
+                                    action: "drop-shape".to_string(),
+                                    project: project_name.clone(),
+                                    key: entry.key.clone(),
+                                    value_shape: shape::classify(raw),
+                                    result: "failed".to_string(),
+                                    var_type: None,
+                                    error: Some(v.to_string()),
+                                },
+                            );
                             continue;
                         }
 
@@ -536,30 +652,38 @@ async fn push_mode(
                                         &project_cfg.targets,
                                     )
                                     .await?;
-                                let _ = append_audit_log(&AuditEntry {
-                                    timestamp: Utc::now().to_rfc3339(),
-                                    action: "update".to_string(),
-                                    project: project_name.clone(),
-                                    key: entry.key.clone(),
-                                    value_shape: shape::classify(raw),
-                                    result: "ok".to_string(),
-                                    error: None,
-                                });
+                                let _ = append_audit_log(
+                                    store,
+                                    &AuditEntry {
+                                        timestamp: Utc::now().to_rfc3339(),
+                                        action: "update".to_string(),
+                                        project: project_name.clone(),
+                                        key: entry.key.clone(),
+                                        value_shape: shape::classify(raw),
+                                        result: "ok".to_string(),
+                                        var_type: None,
+                                        error: None,
+                                    },
+                                );
                             }
                         }
                     }
                     DiffAction::Match => {
                         let secret = store.get(&vault_path)?;
                         let raw = secret.expose_secret();
-                        let _ = append_audit_log(&AuditEntry {
-                            timestamp: Utc::now().to_rfc3339(),
-                            action: "match".to_string(),
-                            project: project_name.clone(),
-                            key: entry.key.clone(),
-                            value_shape: shape::classify(raw),
-                            result: "ok".to_string(),
-                            error: None,
-                        });
+                        let _ = append_audit_log(
+                            store,
+                            &AuditEntry {
+                                timestamp: Utc::now().to_rfc3339(),
+                                action: "match".to_string(),
+                                project: project_name.clone(),
+                                key: entry.key.clone(),
+                                value_shape: shape::classify(raw),
+                                result: "ok".to_string(),
+                                var_type: None,
+                                error: None,
+                            },
+                        );
                     }
                     DiffAction::DropShape => {
                         if !json_output {
@@ -571,15 +695,19 @@ async fn push_mode(
                         }
                         if let Ok(secret) = store.get(&vault_path) {
                             let raw = secret.expose_secret();
-                            let _ = append_audit_log(&AuditEntry {
-                                timestamp: Utc::now().to_rfc3339(),
-                                action: "drop-shape".to_string(),
-                                project: project_name.clone(),
-                                key: entry.key.clone(),
-                                value_shape: shape::classify(raw),
-                                result: "failed".to_string(),
-                                error: entry.reason.clone(),
-                            });
+                            let _ = append_audit_log(
+                                store,
+                                &AuditEntry {
+                                    timestamp: Utc::now().to_rfc3339(),
+                                    action: "drop-shape".to_string(),
+                                    project: project_name.clone(),
+                                    key: entry.key.clone(),
+                                    value_shape: shape::classify(raw),
+                                    result: "failed".to_string(),
+                                    var_type: None,
+                                    error: entry.reason.clone(),
+                                },
+                            );
                         }
                     }
                     DiffAction::Orphan => {
@@ -741,15 +869,19 @@ async fn push_mode_fly(
                     .await
                     .with_context(|| format!("setSecrets failed for Fly app '{}'", app_cfg.app))?;
                 for (key, raw) in &batch {
-                    let _ = append_audit_log(&AuditEntry {
-                        timestamp: Utc::now().to_rfc3339(),
-                        action: "set-fly".to_string(),
-                        project: app_cfg.app.clone(),
-                        key: key.clone(),
-                        value_shape: shape::classify(raw),
-                        result: "ok".to_string(),
-                        error: None,
-                    });
+                    let _ = append_audit_log(
+                        store,
+                        &AuditEntry {
+                            timestamp: Utc::now().to_rfc3339(),
+                            action: "set-fly".to_string(),
+                            project: app_cfg.app.clone(),
+                            key: key.clone(),
+                            value_shape: shape::classify(raw),
+                            result: "ok".to_string(),
+                            var_type: None,
+                            error: None,
+                        },
+                    );
                 }
                 if !json_output {
                     match result.release_version {
@@ -814,10 +946,11 @@ mod tests {
         let mut vars = HashMap::new();
         vars.insert(
             "POSTGRES_URL".to_string(),
-            VarEntry::Object {
+            VarEntry::Object(VarObject {
                 path: "revealui/prod/db/postgres-url".to_string(),
                 shape: Shape::PostgresUrl,
-            },
+                sensitive: false,
+            }),
         );
         let cfg = project_with_vars(vars);
         let (path, shape) = cfg.vault_path_for("POSTGRES_URL");
@@ -923,6 +1056,299 @@ mod tests {
     #[allow(dead_code)]
     fn project_string_only(vars: HashMap<String, String>) -> ProjectSync {
         project_with_string_vars(vars)
+    }
+
+    // ── Sensitive marker (manifest parse + type decision) ────────────────────
+
+    #[test]
+    fn manifest_parses_sensitive_marker() {
+        let toml_src = r#"
+            [projects.api]
+            project_id = "prj_test"
+            vault_prefix = "revealui/vercel/api"
+
+            [projects.api.vars]
+            STRIPE_SECRET_KEY = { path = "revealui/prod/stripe/secret-key", shape = "stripe-key-live-only", sensitive = true }
+            POSTGRES_URL = "revealui/prod/db/postgres-url"
+        "#;
+        let manifest: SyncManifest = toml::from_str(toml_src).unwrap();
+        let api = manifest.projects.get("api").unwrap();
+        assert!(api.sensitive_for("STRIPE_SECRET_KEY"));
+        assert!(!api.sensitive_for("POSTGRES_URL"));
+        // prefix-derived vars carry no marker
+        assert!(!api.sensitive_for("NOT_DECLARED"));
+    }
+
+    #[test]
+    fn manifest_object_entry_shape_is_optional() {
+        let toml_src = r#"
+            [projects.api]
+            project_id = "prj_test"
+            vault_prefix = "revealui/vercel/api"
+
+            [projects.api.vars]
+            REVEALUI_SECRET = { path = "revealui/prod/secret", sensitive = true }
+        "#;
+        let manifest: SyncManifest = toml::from_str(toml_src).unwrap();
+        let api = manifest.projects.get("api").unwrap();
+        let (path, shape) = api.vault_path_for("REVEALUI_SECRET");
+        assert_eq!(path, "revealui/prod/secret");
+        assert_eq!(shape, Shape::Any);
+        assert!(api.sensitive_for("REVEALUI_SECRET"));
+    }
+
+    #[test]
+    fn manifest_rejects_unknown_var_entry_key() {
+        // A typo'd marker must fail the parse loudly — silently ignoring
+        // `sensitve = true` would leave a credential downgradable.
+        let toml_src = r#"
+            [projects.api]
+            project_id = "prj_test"
+            vault_prefix = "revealui/vercel/api"
+
+            [projects.api.vars]
+            STRIPE_SECRET_KEY = { path = "revealui/prod/stripe/secret-key", sensitve = true }
+        "#;
+        assert!(toml::from_str::<SyncManifest>(toml_src).is_err());
+    }
+
+    #[test]
+    fn create_type_for_never_downgrades() {
+        assert_eq!(create_type_for(false, false), EnvVarType::Encrypted);
+        assert_eq!(create_type_for(true, false), EnvVarType::Sensitive);
+        assert_eq!(create_type_for(false, true), EnvVarType::Sensitive);
+        assert_eq!(create_type_for(true, true), EnvVarType::Sensitive);
+    }
+
+    #[test]
+    fn type_drift_reason_only_fires_on_unmet_sensitive_intent() {
+        assert!(type_drift_reason(false, Some("encrypted")).is_none());
+        assert!(type_drift_reason(true, Some("sensitive")).is_none());
+        let drift = type_drift_reason(true, Some("encrypted")).expect("drift");
+        assert!(drift.contains("type drift"), "got: {drift}");
+        assert!(drift.contains("encrypted"), "got: {drift}");
+        let unknown = type_drift_reason(true, None).expect("drift");
+        assert!(unknown.contains("unknown"), "got: {unknown}");
+    }
+
+    // ── push_mode integration (temp store + mock Vercel API) ────────────────
+
+    /// Temp store with a generated age identity — mirrors the pattern from
+    /// core's `rotation::sync_hook` test module.
+    fn setup_temp_store() -> (tempfile::TempDir, PassageStore) {
+        let dir = tempfile::tempdir().unwrap();
+        let store_dir = dir.path().join("store");
+        std::fs::create_dir_all(&store_dir).unwrap();
+
+        let id = age::x25519::Identity::generate();
+        let recipient = id.to_public();
+
+        let id_file = dir.path().join("keys.txt");
+        std::fs::write(
+            &id_file,
+            format!(
+                "# test key\n{}\n",
+                secrecy::ExposeSecret::expose_secret(&id.to_string())
+            ),
+        )
+        .unwrap();
+
+        let recip_file = store_dir.join(".age-recipients");
+        std::fs::write(&recip_file, format!("{}\n", recipient)).unwrap();
+
+        let config = Config {
+            store_dir,
+            identity_file: id_file,
+            recipients_file: recip_file,
+            editor: None,
+            tmpdir: None,
+        };
+        let store = PassageStore::open(config).unwrap();
+        (dir, store)
+    }
+
+    fn single_project_manifest(project: ProjectSync) -> SyncManifest {
+        SyncManifest {
+            team_id: None,
+            projects: HashMap::from([("api".to_string(), project)]),
+        }
+    }
+
+    #[tokio::test]
+    async fn push_mode_recreate_preserves_remote_sensitive_type() {
+        // The 2026-06-10 regression class: the synced target has no row
+        // (deleted / rebuilt), but the key still exists as `sensitive` on
+        // another target. The re-create must come back `sensitive` — not
+        // silently downgrade to `encrypted`.
+        let (_dir, store) = setup_temp_store();
+        store
+            .upsert("revealui/prod/stripe/secret-key", b"sk_live_x")
+            .unwrap();
+
+        let mut server = mockito::Server::new_async().await;
+        let m_list = server
+            .mock("GET", "/projects/prj_p/env")
+            .with_status(200)
+            .with_body(
+                r#"{"envs":[{"id":"e1","key":"STRIPE_SECRET_KEY","target":["preview"],"type":"sensitive"}]}"#,
+            )
+            .create_async()
+            .await;
+        let m_decrypt = server
+            .mock("GET", "/projects/prj_p/env?decrypt=true")
+            .with_status(403)
+            .with_body("{}")
+            .create_async()
+            .await;
+        let m_create = server
+            .mock("POST", "/projects/prj_p/env")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "key": "STRIPE_SECRET_KEY",
+                "target": ["production"],
+                "type": "sensitive",
+            })))
+            .with_status(201)
+            .with_body("{}")
+            .expect(1)
+            .create_async()
+            .await;
+
+        let mut vars = HashMap::new();
+        vars.insert(
+            "STRIPE_SECRET_KEY".to_string(),
+            VarEntry::Path("revealui/prod/stripe/secret-key".to_string()),
+        );
+        let manifest = single_project_manifest(ProjectSync {
+            project_id: "prj_p".to_string(),
+            vault_prefix: "revealui/vercel/api".to_string(),
+            targets: vec!["production".to_string()],
+            skip: vec![],
+            vars,
+        });
+
+        let client = VercelClient::new("t".into(), None).with_base_url(server.url());
+        push_mode(&store, &client, &manifest, true, true)
+            .await
+            .unwrap();
+
+        m_list.assert_async().await;
+        m_decrypt.assert_async().await;
+        m_create.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn push_mode_creates_sensitive_when_manifest_marks_it() {
+        let (_dir, store) = setup_temp_store();
+        store
+            .upsert("revealui/prod/secret", b"super-secret-value")
+            .unwrap();
+
+        let mut server = mockito::Server::new_async().await;
+        let m_list = server
+            .mock("GET", "/projects/prj_p/env")
+            .with_status(200)
+            .with_body(r#"{"envs":[]}"#)
+            .create_async()
+            .await;
+        let m_decrypt = server
+            .mock("GET", "/projects/prj_p/env?decrypt=true")
+            .with_status(403)
+            .with_body("{}")
+            .create_async()
+            .await;
+        let m_create = server
+            .mock("POST", "/projects/prj_p/env")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "key": "REVEALUI_SECRET",
+                "type": "sensitive",
+            })))
+            .with_status(201)
+            .with_body("{}")
+            .expect(1)
+            .create_async()
+            .await;
+
+        let mut vars = HashMap::new();
+        vars.insert(
+            "REVEALUI_SECRET".to_string(),
+            VarEntry::Object(VarObject {
+                path: "revealui/prod/secret".to_string(),
+                shape: Shape::Any,
+                sensitive: true,
+            }),
+        );
+        let manifest = single_project_manifest(ProjectSync {
+            project_id: "prj_p".to_string(),
+            vault_prefix: "revealui/vercel/api".to_string(),
+            targets: vec!["production".to_string()],
+            skip: vec![],
+            vars,
+        });
+
+        let client = VercelClient::new("t".into(), None).with_base_url(server.url());
+        push_mode(&store, &client, &manifest, true, true)
+            .await
+            .unwrap();
+
+        m_list.assert_async().await;
+        m_decrypt.assert_async().await;
+        m_create.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn push_mode_creates_encrypted_by_default() {
+        // No marker + no remote history → the default stays `encrypted`.
+        let (_dir, store) = setup_temp_store();
+        store
+            .upsert("revealui/prod/public/api-url", b"https://api.example.com")
+            .unwrap();
+
+        let mut server = mockito::Server::new_async().await;
+        let m_list = server
+            .mock("GET", "/projects/prj_p/env")
+            .with_status(200)
+            .with_body(r#"{"envs":[]}"#)
+            .create_async()
+            .await;
+        let m_decrypt = server
+            .mock("GET", "/projects/prj_p/env?decrypt=true")
+            .with_status(403)
+            .with_body("{}")
+            .create_async()
+            .await;
+        let m_create = server
+            .mock("POST", "/projects/prj_p/env")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "key": "NEXT_PUBLIC_API_URL",
+                "type": "encrypted",
+            })))
+            .with_status(201)
+            .with_body("{}")
+            .expect(1)
+            .create_async()
+            .await;
+
+        let mut vars = HashMap::new();
+        vars.insert(
+            "NEXT_PUBLIC_API_URL".to_string(),
+            VarEntry::Path("revealui/prod/public/api-url".to_string()),
+        );
+        let manifest = single_project_manifest(ProjectSync {
+            project_id: "prj_p".to_string(),
+            vault_prefix: "revealui/vercel/api".to_string(),
+            targets: vec!["production".to_string()],
+            skip: vec![],
+            vars,
+        });
+
+        let client = VercelClient::new("t".into(), None).with_base_url(server.url());
+        push_mode(&store, &client, &manifest, true, true)
+            .await
+            .unwrap();
+
+        m_list.assert_async().await;
+        m_decrypt.assert_async().await;
+        m_create.assert_async().await;
     }
 
     // ── Fly manifest ─────────────────────────────────────────────────────────

--- a/crates/core/src/rotation/sync_hook.rs
+++ b/crates/core/src/rotation/sync_hook.rs
@@ -30,7 +30,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::store::PassageStore;
 use crate::sync::shape::{self, Shape, ShapeViolation};
-use crate::sync::vercel::VercelClient;
+use crate::sync::vercel::{EnvVarType, VercelClient};
 
 /// Per-provider sync block. Today only Vercel is supported; this
 /// shape leaves room for future targets (`github`, `cloudflare`,
@@ -69,6 +69,12 @@ pub struct VercelEnvVarRef {
     /// Targets to apply the value to. Default `["production"]`.
     #[serde(default = "default_targets")]
     pub targets: Vec<String>,
+    /// Request Vercel type `sensitive` when the sync has to CREATE this
+    /// env var (absent on the project). Updates PATCH value-only and never
+    /// change an existing row's type. Default `false` (creates as
+    /// `encrypted`).
+    #[serde(default)]
+    pub sensitive: bool,
 }
 
 fn default_targets() -> Vec<String> {
@@ -270,8 +276,19 @@ async fn push_to_vercel(
                     .await
             }
             None => {
+                let var_type = if ev.sensitive {
+                    EnvVarType::Sensitive
+                } else {
+                    EnvVarType::Encrypted
+                };
                 client
-                    .create_env_var(&vercel_ref.project_id, &ev.name, value_str, &ev.targets)
+                    .create_env_var(
+                        &vercel_ref.project_id,
+                        &ev.name,
+                        value_str,
+                        &ev.targets,
+                        var_type,
+                    )
                     .await
             }
         };
@@ -307,6 +324,17 @@ mod tests {
         let ev: VercelEnvVarRef = toml::from_str(toml_src).unwrap();
         assert_eq!(ev.name, "POSTGRES_URL");
         assert_eq!(ev.targets, vec!["production".to_string()]);
+        assert!(!ev.sensitive, "sensitive must default to false");
+    }
+
+    #[test]
+    fn vercel_env_var_ref_sensitive_marker_parses() {
+        let toml_src = r#"
+            name = "STRIPE_WEBHOOK_SECRET"
+            sensitive = true
+        "#;
+        let ev: VercelEnvVarRef = toml::from_str(toml_src).unwrap();
+        assert!(ev.sensitive);
     }
 
     #[test]
@@ -449,10 +477,12 @@ mod tests {
                     VercelEnvVarRef {
                         name: "POSTGRES_URL".into(),
                         targets: vec!["production".into(), "preview".into()],
+                        sensitive: false,
                     },
                     VercelEnvVarRef {
                         name: "POSTGRES_NEW".into(),
                         targets: vec!["production".into()],
+                        sensitive: false,
                     },
                 ],
             }),
@@ -490,6 +520,7 @@ mod tests {
                 env_vars: vec![VercelEnvVarRef {
                     name: "POSTGRES_URL".into(),
                     targets: vec!["production".into()],
+                    sensitive: false,
                 }],
             }),
         };
@@ -505,6 +536,64 @@ mod tests {
         assert_eq!(log.len(), 1);
         assert_eq!(log[0].status, "failed");
         assert!(log[0].error.as_deref().unwrap_or("").contains("api-token"));
+    }
+
+    /// The rotation chain's create-fallback honors `sensitive = true`:
+    /// a rotated credential that has to be created fresh must not land
+    /// as a UI-revealable `encrypted` row.
+    #[tokio::test]
+    async fn rotation_create_fallback_requests_sensitive_when_marked() {
+        let (_dir, store) = setup_temp_store();
+        store
+            .upsert("credentials/vercel/api-token", b"token-x")
+            .unwrap();
+
+        let mut server = mockito::Server::new_async().await;
+        let m_list = server
+            .mock("GET", "/projects/prj/env")
+            .with_status(200)
+            .with_body(r#"{"envs":[]}"#)
+            .expect(1)
+            .create_async()
+            .await;
+        let m_create = server
+            .mock("POST", "/projects/prj/env")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "key": "STRIPE_WEBHOOK_SECRET",
+                "type": "sensitive",
+            })))
+            .with_status(201)
+            .with_body("{}")
+            .expect(1)
+            .create_async()
+            .await;
+
+        let sync = SyncConfig {
+            vercel: Some(VercelSyncRef {
+                api_token_path: "credentials/vercel/api-token".into(),
+                project_id: "prj".into(),
+                team_id: None,
+                env_vars: vec![VercelEnvVarRef {
+                    name: "STRIPE_WEBHOOK_SECRET".into(),
+                    targets: vec!["production".into()],
+                    sensitive: true,
+                }],
+            }),
+        };
+
+        let log = apply_sync_after_rotation_inner(
+            &store,
+            &sync,
+            &SecretString::from("whsec_new"),
+            Some(&server.url()),
+        )
+        .await;
+
+        assert_eq!(log.len(), 1);
+        assert_eq!(log[0].status, "success", "row failed: {:?}", log[0]);
+
+        m_list.assert_async().await;
+        m_create.assert_async().await;
     }
 
     /// Proves the bug class: a rotation provider returning an empty string
@@ -524,6 +613,7 @@ mod tests {
                 env_vars: vec![VercelEnvVarRef {
                     name: "POSTGRES_URL".into(),
                     targets: vec!["production".into()],
+                    sensitive: false,
                 }],
             }),
         };
@@ -553,6 +643,7 @@ mod tests {
                 env_vars: vec![VercelEnvVarRef {
                     name: "POSTGRES_URL".into(),
                     targets: vec!["production".into()],
+                    sensitive: false,
                 }],
             }),
         };

--- a/crates/core/src/sync/mod.rs
+++ b/crates/core/src/sync/mod.rs
@@ -13,4 +13,4 @@ pub mod vercel;
 
 pub use fly::{FlyClient, FlySecret};
 pub use shape::{Shape, ShapeViolation};
-pub use vercel::{VercelClient, VercelEnvVar};
+pub use vercel::{EnvVarType, VercelClient, VercelEnvVar};

--- a/crates/core/src/sync/vercel.rs
+++ b/crates/core/src/sync/vercel.rs
@@ -53,6 +53,40 @@ pub struct VercelEnvVar {
     pub configuration_id: Option<String>,
 }
 
+impl VercelEnvVar {
+    /// True when this remote row is Vercel type `sensitive` — encrypted at
+    /// rest AND never returned in plaintext by the UI or API after write.
+    pub fn is_sensitive(&self) -> bool {
+        self.var_type.as_deref() == Some("sensitive")
+    }
+}
+
+/// Env-var `type` written on create.
+///
+/// Vercel distinguishes `encrypted` (encrypted at rest, but any project
+/// member can reveal the plaintext in the UI / API) from `sensitive`
+/// (encrypted at rest, plaintext never returned after write). Credentials
+/// that can charge cards, forge webhooks, or sign tokens belong in
+/// `Sensitive`. This client never writes the other Vercel types (`plain`,
+/// `system`, legacy `secret`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EnvVarType {
+    /// Vercel default — any project member can reveal the value.
+    Encrypted,
+    /// Write-only after create; the UI/API never return the plaintext.
+    Sensitive,
+}
+
+impl EnvVarType {
+    /// Wire value for the Vercel `type` field.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Encrypted => "encrypted",
+            Self::Sensitive => "sensitive",
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 struct VercelEnvListResponse {
     envs: Vec<VercelEnvVar>,
@@ -178,22 +212,32 @@ impl VercelClient {
         Ok(Some(data.envs))
     }
 
-    /// Create a new env var. The Vercel API rejects duplicates with
-    /// 409; callers detect existing rows via [`Self::list_env_vars`]
-    /// + dispatch to [`Self::update_env_var`] when present.
+    /// Create a new env var with the requested [`EnvVarType`]. The Vercel
+    /// API rejects duplicates with 409; callers detect existing rows via
+    /// [`Self::list_env_vars`] + dispatch to [`Self::update_env_var`] when
+    /// present.
+    ///
+    /// The `type` is part of the POST body. If Vercel rejects the requested
+    /// type, the error names that type and the call fails — there is
+    /// deliberately no fallback that retries with a downgraded type.
+    /// Re-creating a sensitive credential as `encrypted` is the
+    /// silent-downgrade class this parameter closes (observed 2026-06-10:
+    /// a sync apply re-created sensitive Stripe + signing secrets as
+    /// UI-revealable `encrypted` rows).
     pub async fn create_env_var(
         &self,
         project_id: &str,
         key: &str,
         value: &str,
         targets: &[String],
+        var_type: EnvVarType,
     ) -> anyhow::Result<()> {
         let url = self.base_url(project_id);
         let body = serde_json::json!({
             "key": key,
             "value": value,
             "target": targets,
-            "type": "encrypted",
+            "type": var_type.as_str(),
         });
 
         let req = self.client.post(&url).bearer_auth(&self.token).json(&body);
@@ -202,7 +246,13 @@ impl VercelClient {
         if !resp.status().is_success() {
             let status = resp.status();
             let body = resp.text().await.unwrap_or_default();
-            bail!("Failed to create env var '{}': {} {}", key, status, body);
+            bail!(
+                "Failed to create env var '{}' (requested type={}): {} {}",
+                key,
+                var_type.as_str(),
+                status,
+                body
+            );
         }
         Ok(())
     }
@@ -391,9 +441,70 @@ mod tests {
                 "POSTGRES_URL",
                 "postgres://...",
                 &["production".to_string()],
+                EnvVarType::Encrypted,
             )
             .await
             .unwrap();
+
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn create_env_var_posts_sensitive_type_when_requested() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/projects/p/env")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "key": "STRIPE_SECRET_KEY",
+                "type": "sensitive",
+            })))
+            .with_status(201)
+            .with_body("{}")
+            .create_async()
+            .await;
+
+        let client = VercelClient::new("t".into(), None).with_base_url(server.url());
+        client
+            .create_env_var(
+                "p",
+                "STRIPE_SECRET_KEY",
+                "sk_live_x",
+                &["production".to_string()],
+                EnvVarType::Sensitive,
+            )
+            .await
+            .unwrap();
+
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn create_env_var_rejected_type_fails_loudly_naming_the_type() {
+        // If the API refuses the requested type there must be no silent
+        // fallback to a downgraded type — the error surfaces and names it.
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/projects/p/env")
+            .with_status(400)
+            .with_body(r#"{"error":{"message":"type not allowed"}}"#)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let client = VercelClient::new("t".into(), None).with_base_url(server.url());
+        let err = client
+            .create_env_var(
+                "p",
+                "STRIPE_SECRET_KEY",
+                "sk_live_x",
+                &["production".to_string()],
+                EnvVarType::Sensitive,
+            )
+            .await
+            .expect_err("400 must surface");
+        let msg = format!("{err}");
+        assert!(msg.contains("type=sensitive"), "got: {msg}");
+        assert!(msg.contains("400"), "got: {msg}");
 
         mock.assert_async().await;
     }

--- a/docs/MASTER_SPEC.md
+++ b/docs/MASTER_SPEC.md
@@ -160,6 +160,13 @@ skip = ["VERCEL_AUTOMATION_TOKEN"] # var names to skip (integration-managed, etc
 [projects.revealui-prod.vars]
 DATABASE_URL = "revealui/prod/neon/postgres-url"
 STRIPE_SECRET_KEY = "revealui/prod/stripe/secret-key"
+
+# Inline-table form — optional `shape` constraint + optional `sensitive` marker.
+# sensitive = true requests Vercel type `sensitive` on CREATE: the plaintext is
+# never revealable in the Vercel UI/API after write. Use for credentials
+# (Stripe keys, webhook secrets, signing/JWT secrets). Updates PATCH value-only
+# and never change an existing row's type (flip = delete + re-create).
+STRIPE_WEBHOOK_SECRET = { path = "revealui/prod/stripe/webhook-secret", shape = "stripe-webhook", sensitive = true }
 ```
 
 The default behavior maps every `<vault_prefix>/<name>` to env var `NAME` for each target in `targets`. The per-var `[projects.<slug>.vars]` table maps a Vercel var name to a literal vault path, overriding the default prefix-based naming.
@@ -167,6 +174,8 @@ The default behavior maps every `<vault_prefix>/<name>` to env var `NAME` for ea
 ### Sync semantics
 
 - `value-only PATCH` to Vercel API to preserve env-var type + target on update (`aa5ebf5`)
+- CREATE requests Vercel type `sensitive` when the manifest marks the var `sensitive = true` OR any existing remote row with the same key is `sensitive` (preserve-on-re-create; sensitivity is never silently downgraded — 0.3.0). A rejected type fails the apply loudly naming the requested type; there is no fallback to `encrypted`.
+- Type drift (manifest wants `sensitive`, remote row is not) is surfaced as a diff annotation; flipping an existing row requires delete + re-create.
 - `remote_map` filtered by `target` to avoid multi-environment ID collision (`b571920`)
 - Manifest schema enforced via `serde` deserialization
 - Dry-run prints unified diff between vault state and remote state


### PR DESCRIPTION
## Payload

Promotes `test` → `main`. Content delta is exactly one change-set: **revvault 0.3.0 (#84)** — `sync vercel` no longer silently downgrades Vercel `sensitive` env vars to `encrypted` on re-create. (The two backflow merge commits in the range carry no new content; `test ⊇ main`, reverse-delta empty.)

What 0.3.0 ships:

- `create_env_var` takes an explicit env-var type; a type rejected by the Vercel API fails loudly **naming the requested type** — no fallback to `encrypted`.
- Creates preserve sensitivity from any remote row with the same key (any target).
- Per-var manifest marker `KEY = { path = "...", sensitive = true }` (`shape` optional; unknown keys rejected at parse so a typo'd marker fails loudly). Rotation `env_vars` accept the same flag for the create-fallback.
- Diff annotates sensitive creates and warns on manifest-vs-remote type drift; the JSONL audit log records `var_type` on creates.
- `doctor` tolerates the marker + optional shape. Version 0.2.0 → 0.3.0, CHANGELOG + MASTER_SPEC updated.

## Why promote now

`main` still carries the 0.2.0-era hardcoded `type=encrypted` create path — anyone building or installing from `main` reintroduces the silent-downgrade bug. The deployed sync manifest (revealui `test`) now uses the `sensitive = true` markers, which 0.2.0 fails to parse.

## Validation

- #84 merged with full CI green: 20/20 checks, 2×-consecutive clean reads (3-OS core+cli tests incl. Windows + macOS, Tauri builds, clippy/doc/fmt `-D warnings`, cargo audit/deny, gitleaks, leak scan, MSRV).
- The 0.3.0 binary has since been exercised against production: marked-manifest parse, `doctor`, dry-run sync, and the one-time sensitive re-flip verification — all clean.

## Merge instructions

Owner-gated manual merge with a **merge commit** (no squash — preserves lineage for backflow arithmetic). No auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
