### PR TITLE
promote: test to main (2026-06-12)

### DIFF
--- a/.github/workflows/backflow-main-into-test.yml
+++ b/.github/workflows/backflow-main-into-test.yml
@@ -10,6 +10,6 @@ on:
 
 jobs:
   backflow:
-    # Pinned to immutable SHA (resolved 2026-05-28); update via gh api repos/RevealUIStudio/.github/commits/main
-    uses: RevealUIStudio/.github/.github/workflows/backflow-reusable.yml@70e208a976bbdf46516135fba83aee02fe5718da
+    # Pinned to immutable SHA (resolved 2026-06-12); update via gh api repos/RevealUIStudio/.github/commits/main
+    uses: RevealUIStudio/.github/.github/workflows/backflow-reusable.yml@018dbca12f2b6588b456cb2f450aadf4814729cd # main @ 2026-06-12
     secrets: inherit

--- a/.github/workflows/promotion-gate.yml
+++ b/.github/workflows/promotion-gate.yml
@@ -41,7 +41,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4 (resolved 2026-05-19)
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0


### PR DESCRIPTION
Promotion: test to main (2026-06-12)

Included:
- chore/node24-action-pins -- bump action pins to node24 (deadline 2026-06-16)
- backflow merge (main into test)

Merge: use MERGE COMMIT (not squash).
