### PR TITLE
fix(security): pin frontend undici >=7.28.0 (GHSA-vmh5-mc38-953g)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,5 +30,10 @@
     "typescript": "^6.0.3",
     "vite": "^8.0.16",
     "vitest": "^4.1.8"
+  },
+  "pnpm": {
+    "overrides": {
+      "undici": ">=7.28.0 <8"
+    }
   }
 }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  undici: '>=7.28.0 <8'
+
 importers:
 
   .:
@@ -724,8 +727,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   update-browserslist-db@1.2.3:
@@ -1221,7 +1224,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.25.0
+      undici: 7.28.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -1412,7 +1415,7 @@ snapshots:
 
   typescript@6.0.3: {}
 
-  undici@7.25.0: {}
+  undici@7.28.0: {}
 
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:


### PR DESCRIPTION
jsdom pulled undici 7.25.0 (HIGH SOCKS5 TLS-bypass GHSA-vmh5-mc38-953g + moderate cache-bypass), both patched in 7.28.0. Override scoped to the 7.x line to stay compatible with jsdom 29. pnpm install also reconciled the frontend lockfile, which had drifted behind package.json declared ranges (vite, vitest, tailwind). Validated: pnpm build + pnpm test pass; pnpm audit --audit-level=high clean. Clears the failing pnpm audit (frontend) CI check.