### PR TITLE
fix(security): bump quinn-proto → 0.11.15 (RUSTSEC-2026-0185)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4107,9 +4107,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
Resolves **RUSTSEC-2026-0185** (remote memory exhaustion in `quinn-proto`, advisory published 2026-06-22) that was blocking the test→main promotion (#103). Lockfile-only patch bump 0.11.14 → 0.11.15; `cargo audit` exits clean locally. Unblocks #103.