### PR TITLE
fix(deps): bump rand 0.8.5 to 0.8.6 (GHSA-cq8v-f236-94qc)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ dependencies = [
  "lazy_static",
  "nom",
  "pin-project",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rust-embed",
  "scrypt",
  "sha2",
@@ -56,7 +56,7 @@ dependencies = [
  "hkdf",
  "io_tee",
  "nom",
- "rand 0.8.5",
+ "rand 0.8.6",
  "secrecy",
  "sha2",
 ]
@@ -3708,7 +3708,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
 dependencies = [
  "phf_shared 0.10.0",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -3718,7 +3718,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -4172,9 +4172,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",


### PR DESCRIPTION
## What

Bumps `rand` 0.8.5 to 0.8.6 in `Cargo.lock` (lockfile-only) to remediate Dependabot alert #2 / `GHSA-cq8v-f236-94qc` ("Rand is unsound with a custom logger using `rand::rng()`", vulnerable range `>= 0.7.0, < 0.8.6`).

`rand 0.8.x` sits on the runtime crypto path (the `age` / `age-core` encryption crates) and in the `phf_generator` 0.10/0.11 build chain. 0.8.6 is a semver-compatible patch within `^0.8`.

## How it was produced

`cargo update -p rand@0.8.5 --precise 0.8.6` (no other crates touched), then `cargo check --workspace` passes locally. The diff is `Cargo.lock` only.

## Residual exposure (please read before assuming this closes the alert)

This removes the vulnerable `rand 0.8.5`, but the lockfile still resolves `rand 0.7.3`, which is also inside the advisory range. That instance is **build-time only** and deeply transitive:

```
rand 0.7.3
  <- phf_generator 0.8 <- phf_codegen 0.8 (build-dep) <- selectors 0.24
  <- kuchikiki 0.8.8-speedreader <- tauri-utils 2.9.3
  <- tauri-build / tauri-codegen (Tauri 2.11.3)
```

It is pinned by Tauri's HTML/CSS codegen toolchain and is not reachable by `cargo update` within `tauri = "2"` (the latest Tauri 2.x stack still resolves `phf 0.8 -> rand 0.7.3`). It never reaches a runtime RNG path. The project already documents acceptance of this advisory in `deny.toml` (`RUSTSEC-2026-0097`: no custom logger touches `thread_rng`).

So Dependabot alert #2 may stay open after merge until `rand 0.7.3` is dropped upstream by Tauri. This PR is a genuine reduction of the vulnerable surface, not a full alert close.

## Not addressed here

`glib` (alert #1 / `GHSA-wrw7-89jp-8q8g`, medium, `VariantStrIter` unsoundness) is pinned at 0.18.5 by the Tauri 2.x gtk-rs 0.18 stack and cannot reach the patched 0.20.0 without a major upstream Tauri / webkit2gtk migration. Out of scope for a lockfile bump.
