### PR TITLE
docs: use canonical license-signing-private-key in path examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Paths are lower-kebab, grouped by repo or product, then by subsystem:
 | `revealui/prod/<subsystem>/<name>` | `revealui/prod/neon/postgres-url`, `revealui/prod/stripe/secret-key`, `revealui/prod/stripe/webhook-secret` |
 | `revealui/prod/storage/r2/<name>` | `revealui/prod/storage/r2/access-key-id` |
 | `revforge/customers/<slug>/<name>` | `revforge/customers/acme/admin-password` |
-| `revdev/<name>` | `revdev/license-signing-key` |
+| `revdev/<name>` | `revdev/license-signing-private-key` |
 | `credentials/<system>/<name>` | `credentials/github/personal-token`, `credentials/anthropic/api-key` |
 
 New paths get a `docs/SECRETS.md` entry in the relevant repo. Mirroring to CI is a publish step, never hand-typed.

--- a/docs/MASTER_SPEC.md
+++ b/docs/MASTER_SPEC.md
@@ -87,7 +87,7 @@ revealui/prod/neon/postgres-url
 revealui/prod/stripe/secret-key
 revealui/prod/stripe/webhook-secret
 revealcoin/mint-authority.json
-revdev/license-signing-key
+revdev/license-signing-private-key
 credentials/github/<account>
 credentials/anthropic/<account>
 ssh/<host>/<key-name>


### PR DESCRIPTION
Doc-only. The README path-convention table (`README.md:109`) and the MASTER_SPEC example list (`docs/MASTER_SPEC.md:90`) illustrated the `revdev/<name>` namespace with the **retired** `revdev/license-signing-key` (the legacy pair superseded by the canonical Ed25519 keypair). Updated both to the current `revdev/license-signing-private-key`.

Completes the cross-fleet license-path reconciliation (pairs with revealui #1662, which fixes `docs/SECRETS.md`).

Base `test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)