### PR TITLE
fix(ci): backport lit-username + abs-wsl-windows-user leak-scanner patterns

### DIFF
--- a/.leakignore
+++ b/.leakignore
@@ -9,3 +9,8 @@
 # Test fixtures use a generic placeholder username in store_dir /
 # identity_file path fixtures (not a real developer's home).
 frontend/src/components/SetupScreen.test.tsx   abs-home-path
+
+# By-design: the anti-regression CI job must name the /mnt/c/Users literal in
+# its grep pattern to scan for it. This is the workflow that enforces the
+# rule, not a leak of it (mirrors revkit's bare-username entry).
+.github/workflows/ci.yml                abs-wsl-windows-user

--- a/scripts/check-no-private-leaks.sh
+++ b/scripts/check-no-private-leaks.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # check-no-private-leaks.sh
 #
-# Scans a public-facing directory (default: the revskills repo root) for
+# Scans a public-facing directory (default: the revvault repo root) for
 # references to private filesystem paths, private repos, or machine-local
 # user homes that must not appear in public artifacts.
 #
@@ -37,8 +37,10 @@ unset _path
 # Each entry: tag|ERE_regex|reason
 # Anchored where possible to keep false-positive noise low.
 PATTERNS=(
+  "lit-username|joshua[-]v-dev|literal developer username; use a placeholder"
   "abs-home-path|/home/[a-z][a-z0-9_-]+|absolute user home path (/home/<username>/...)"
   "abs-windows-user|[Cc]:[\\\\/]Users[\\\\/][A-Za-z0-9_-]+|absolute Windows user path (C:\\\\Users\\\\<name>)"
+  "abs-wsl-windows-user|/mnt/[a-z]/Users/[A-Za-z0-9_-]+|WSL mount of a Windows user path (/mnt/c/Users/<name>)"
   "private-jv-repo|/?revfleet/\\.jv|private repo path (~/revfleet/.jv/...)"
   "private-jv-name|revealui-jv|private repo name (revealui-jv)"
   "lts-drive|/mnt/e/|LTS drive mount path"


### PR DESCRIPTION
## What

Fleet-wide follow-up to the 2026-07-02 audit — reconcile the vendored leak scanner so every repo carries the same username-evasion coverage revskills/revkit/revcon now have:

- add `lit-username` (developer-username literal) — this repo lacked it;
- add `abs-wsl-windows-user` (`/mnt/<x>/Users/<name>`) — the WSL-mount spelling the `C:\Users`-only `abs-windows-user` rule misses;
- fix the stale "(default: the revskills repo root)" header.

## Verification
- `bash -n` clean; `scripts/check-no-private-leaks.sh` → exit 0 with the new patterns armed (no self-trip on tracked content).

## Base
Targets `test`. Manual merge only.
