### PR TITLE
fix(ci): unblock RustSec audit — scoped quick-xml ignores + self-expiring guard

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,27 @@
+# cargo-audit configuration.
+#
+# Ignores are TEMPORARY, scoped to exact advisory IDs, and each entry must
+# carry: why it is unreachable, the exposure assessment, and the removal
+# condition. Empty ignore list is the steady state. Every entry here MUST
+# be paired with a stale-ignore guard step in the ci.yml audit job that
+# fails the build when the entry becomes removable — an ignore is never
+# allowed to outlive its justification silently.
+
+[advisories]
+ignore = [
+    # RUSTSEC-2026-0194 + RUSTSEC-2026-0195: quick-xml < 0.41.0 NsReader
+    # memory-exhaustion DoS (severity 7.5). Transitive-only: quick-xml
+    # comes in via plist -> tauri-utils (Tauri bundler/config plist
+    # parsing); revvault code never feeds it attacker-controlled input at
+    # runtime, and the impact is availability-only (no secrecy impact).
+    # The fix (quick-xml 0.41.0) is unreachable today: latest plist 1.9.0
+    # requires quick-xml ^0.39 (lockfile is bumped to plist 1.9.0 /
+    # quick-xml 0.39.4, the closest reachable versions). Upstream bump is
+    # tracked at https://github.com/ebarnard/rust-plist/issues/191.
+    # REMOVAL: enforced by the "Stale-ignore guard" step in ci.yml — it
+    # fails the audit job as soon as `cargo update -p plist` can reach
+    # quick-xml >=0.41; at that point bump the lockfile, delete both
+    # entries, and delete the guard step.
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
+]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,6 +222,24 @@ jobs:
         run: cargo install cargo-audit --locked
       - name: cargo audit
         run: cargo audit
+      - name: Stale-ignore guard — RUSTSEC-2026-0194/0195 (quick-xml)
+        # .cargo/audit.toml carries two quick-xml ignores that are valid
+        # ONLY while the fix (quick-xml >=0.41) is unreachable through
+        # plist (upstream: ebarnard/rust-plist#191). The moment a plist
+        # release makes it reachable, this step fails the build so the
+        # ignores cannot silently outlive their justification. Then: run
+        # `cargo update -p plist`, delete both ignores from
+        # .cargo/audit.toml, and delete this step.
+        run: |
+          target="$(cargo update --dry-run -p plist 2>&1 | awk '/Updating quick-xml/ {print $NF}')"
+          echo "quick-xml reachable via 'cargo update -p plist': ${target:-none (lockfile already at ceiling)}"
+          case "$target" in
+            ""|v0.39.*|v0.40.*)
+              echo "quick-xml >=0.41 still unreachable — the audit.toml ignores remain justified." ;;
+            *)
+              echo "::error::quick-xml $target is now reachable; >=0.41 fixes RUSTSEC-2026-0194/0195. Bump the lockfile, remove both ignores from .cargo/audit.toml, and delete this guard step."
+              exit 1 ;;
+          esac
 
   deny:
     # cargo-deny checks: license compliance (allow-list in deny.toml),

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3847,9 +3847,9 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plist"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.13.0",
@@ -4078,9 +4078,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
 ]


### PR DESCRIPTION
## Summary

Unblocks the fleet-wide `cargo audit (RustSec)` red (first seen on PR #111, but present on every branch): RUSTSEC-2026-0194 + RUSTSEC-2026-0195 — quick-xml <0.41 `NsReader` memory-exhaustion DoS (severity 7.5), transitive via `plist` -> `tauri-utils` (Tauri stack; revvault code never uses quick-xml directly).

**Why not just upgrade:** the fixed `quick-xml 0.41.0` is unreachable — latest `plist 1.9.0` caps at `^0.39` (verified via OSV patched ranges + `cargo update` dry-runs). Upstream bump tracked at ebarnard/rust-plist#191.

**What this PR does (durable-interim, self-expiring):**
- `Cargo.lock`: `plist 1.8.0 -> 1.9.0`, `quick-xml 0.38.4 -> 0.39.4` (closest reachable).
- `.cargo/audit.toml` (new): exact-ID ignores for the two advisories with full justification (build-time plist parsing only; availability impact only; no attacker-controlled runtime input).
- **Stale-ignore guard** in the audit job: dry-runs `cargo update -p plist` and FAILS the build the moment quick-xml >=0.41 becomes reachable — the ignores cannot silently rot; removal is CI-enforced, not memory-dependent.

Verified locally: `cargo audit` exit 0 (0 vulnerabilities, 20 pre-existing allowed unmaintained warnings); guard logic exercised against current state (PASS) and the fail branch reviewed.

After this merges to `test`, re-run / rebase PR #111 — its only red was this check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
