### PR TITLE
ci: add issue/PR body leak-scan gate

### DIFF
--- a/.github/workflows/issue-leak-scan.yml
+++ b/.github/workflows/issue-leak-scan.yml
@@ -1,0 +1,144 @@
+name: Issue + PR Body Leak Scan
+
+on:
+  issues:
+    types: [opened, edited]
+  pull_request_target:
+    types: [opened, edited]
+  issue_comment:
+    types: [created, edited]
+
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+
+concurrency:
+  group: leak-scan-${{ github.event.issue.number || github.event.pull_request.number }}-${{ github.event.action }}
+  cancel-in-progress: false
+
+jobs:
+  scan:
+    name: Scan body via gitleaks
+    # Skip bot-authored events to avoid loops on our own remediation comments.
+    if: >-
+      github.actor != 'github-actions[bot]'
+      && github.actor != 'dependabot[bot]'
+      && github.actor != 'chatgpt-codex-connector[bot]'
+      && (github.event.comment == null || github.event.comment.user.type != 'Bot')
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    env:
+      GITLEAKS_VERSION: "8.30.0"
+      # SHA256 of gitleaks_<ver>_linux_x64.tar.gz (from gitleaks_<ver>_checksums.txt);
+      # verified before install to close the curl|tar supply-chain gap. Bump with VERSION.
+      GITLEAKS_SHA256: "79a3ab579b53f71efd634f3aaf7e04a0fa0cf206b7ed434638d1547a2470a66e"
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Install gitleaks
+        run: |
+          set -euo pipefail
+          tarball="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${tarball}" -o "/tmp/${tarball}"
+          echo "${GITLEAKS_SHA256}  /tmp/${tarball}" | sha256sum -c -
+          tar -xzf "/tmp/${tarball}" -C /tmp gitleaks
+          sudo install -m 0755 /tmp/gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+
+      - name: Scan + comment + label on findings
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fs = require('node:fs/promises');
+            const { spawnSync } = require('node:child_process');
+            const path = require('node:path');
+
+            // Read body via context API — no shell interpolation of user input.
+            const body =
+              context.payload.comment?.body
+              ?? context.payload.issue?.body
+              ?? context.payload.pull_request?.body
+              ?? '';
+            const issueNumber =
+              context.payload.issue?.number
+              ?? context.payload.pull_request?.number;
+
+            if (!body || !issueNumber) {
+              core.info('No body or issue number — nothing to scan.');
+              return;
+            }
+
+            const scanDir = '/tmp/scan-payload';
+            await fs.mkdir(scanDir, { recursive: true });
+            await fs.writeFile(path.join(scanDir, 'body.txt'), body, 'utf8');
+
+            const result = spawnSync('gitleaks', [
+              'detect',
+              '--no-banner',
+              '--redact',
+              '--no-git',
+              '--config', '.gitleaks.issues.toml',
+              '--source', scanDir,
+              '--report-format', 'json',
+              '--report-path', '/tmp/scan-report.json',
+            ], { encoding: 'utf8' });
+
+            core.info(`gitleaks exit: ${result.status}`);
+            if (result.stderr) {
+              core.info(result.stderr.slice(0, 4000));
+            }
+
+            let findings = [];
+            try {
+              const txt = await fs.readFile('/tmp/scan-report.json', 'utf8');
+              findings = JSON.parse(txt || '[]');
+            } catch (_) {
+              findings = [];
+            }
+
+            if (findings.length === 0) {
+              core.info('No findings.');
+              return;
+            }
+
+            const rules = [...new Set(findings.map(f => f.RuleID))].slice(0, 8);
+            const commentBody = [
+              '> [!CAUTION]',
+              '> **Possible sensitive content detected.**',
+              '',
+              `Gitleaks flagged \`${findings.length}\` match(es) across rule(s): \`${rules.join('`, `')}\`.`,
+              '',
+              '**Action required:**',
+              '1. If this contains a **real secret** (`sk_*`, `whsec_*`, password, token, DB URL with credentials, wallet private key): **rotate it now** — editing the body does NOT remove it from GitHub edit history.',
+              '2. Edit the body and replace the sensitive content with placeholders (e.g. `acct_REDACTED`, `<dev-api>`, `<private design doc>`).',
+              '3. To erase the original from edit history entirely, delete + recreate the issue/comment.',
+              '4. Once cleaned, remove the `contains-sensitive-content` label.',
+              '',
+              '_Triggered by `.github/workflows/issue-leak-scan.yml` (rules in `.gitleaks.issues.toml`)._',
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              body: commentBody,
+            });
+
+            // Best-effort label add; idempotent — repeated runs won't duplicate.
+            try {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                labels: ['contains-sensitive-content'],
+              });
+            } catch (err) {
+              core.warning(`addLabels failed: ${err.message}`);
+            }
+
+            core.setFailed(`${findings.length} sensitive match(es) flagged. Body/comment labelled.`);

--- a/.gitleaks.issues.toml
+++ b/.gitleaks.issues.toml
@@ -1,0 +1,122 @@
+# Issue/PR/comment-body gitleaks config for RevealUI.
+#
+# REGEX-CONFIG-BOUNDARY — this file contains gitleaks rule patterns per the
+# project no-regex rule (M2). gitleaks is the third-party regex engine; we
+# box its config strings here under the documented boundary exception.
+#
+# Consumer: .github/workflows/issue-leak-scan.yml only.
+# Code-side scanning continues to use .gitleaks.toml (default rules + repo
+# allowlists). This file extends those defaults with patterns that catch
+# the leak classes the 2026-05-11 issue-audit found across the open
+# issue corpus — Stripe object IDs, internal subdomains, private-repo
+# path refs, founder home paths, Sentry DSNs, DB connection strings,
+# EVM wallets, personal-domain emails.
+#
+# Pairs with memory `reference_issue_leak_scan_workflow.md` and the audit
+# punch list at §Pre-Flip Moral Readiness in the internal master plan.
+
+title = "RevealUI issue/PR body leak scan"
+
+[extend]
+useDefault = true
+
+[[rules]]
+id = "revealui-stripe-customer-correlation"
+description = "Stripe customer / subscription / invoice / charge / payment-intent IDs (correlation risk in public issues)"
+regex = '''\b(cus|sub|in|ch|pi|seti|ba|src|tok)_(test_|live_)?[A-Za-z0-9]{14,}\b'''
+keywords = ["cus_", "sub_", "in_", "ch_", "pi_", "seti_", "ba_", "src_", "tok_"]
+tags = ["pii", "stripe", "boundary-config"]
+
+[[rules]]
+id = "revealui-stripe-account-and-catalog"
+description = "Stripe account / product / price / plan / billing-portal / webhook-endpoint / meter IDs (operator catalog disclosure)"
+regex = '''\b(acct|prod|price|plan|bpc|we|mtr|mtr_test|mtr_live)_(test_|live_)?[A-Za-z0-9_]{14,}\b'''
+keywords = ["acct_", "prod_", "price_", "plan_", "bpc_", "we_", "mtr_"]
+tags = ["operator", "stripe", "boundary-config"]
+
+[[rules]]
+id = "revealui-internal-subdomain"
+description = "Internal RevealUI dev/test/staging/internal API subdomains"
+regex = '''https?://(dev|test|staging|internal|preview)\.api\.revealui\.com'''
+keywords = ["dev.api.revealui", "test.api.revealui", "staging.api.revealui", "internal.api.revealui", "preview.api.revealui"]
+tags = ["internal-url", "boundary-config"]
+
+[[rules]]
+id = "revealui-private-repo-path"
+description = "References to revealui-jv private repo paths or .jv/ trees under fleet"
+regex = '''(revealui-jv/(business|docs/audits|docs/gaps|docs/decisions|\.claude)|~/(revfleet|suite)/\.jv/|/home/joshua-v-dev/(revfleet|suite)/\.jv/)'''
+keywords = ["revealui-jv/", ".jv/", "~/revfleet/.jv", "~/suite/.jv"]
+tags = ["private-repo", "boundary-config"]
+
+[[rules]]
+id = "revealui-founder-home-path"
+description = "Founder absolute filesystem paths (WSL or Windows host)"
+regex = '''(/home/joshua-v-dev/|\\\\wsl\.localhost\\Ubuntu\\home\\joshua-v-dev|C:\\Users\\joshu\\)'''
+keywords = ["/home/joshua-v-dev", "joshua-v-dev", "wsl.localhost\\Ubuntu", "C:\\Users\\joshu"]
+tags = ["pii", "founder-path", "boundary-config"]
+
+[[rules]]
+id = "revealui-sentry-dsn"
+description = "Sentry DSN URL (sender spoof + project disclosure)"
+regex = '''https://[a-f0-9]{32}@[a-z0-9.-]+\.ingest\.(us\.|de\.)?sentry\.io/[0-9]+'''
+keywords = ["ingest.sentry.io", "ingest.us.sentry.io", "ingest.de.sentry.io"]
+tags = ["sentry", "boundary-config"]
+
+[[rules]]
+id = "revealui-postgres-connection-with-credentials"
+description = "Postgres / MySQL / Mongo connection string with embedded credentials"
+regex = '''\b(postgres(ql)?|mysql|mongodb(\+srv)?)://[^/\s:]+:[^@\s]+@'''
+keywords = ["postgres://", "postgresql://", "mysql://", "mongodb://", "mongodb+srv://"]
+tags = ["secret", "boundary-config"]
+
+[[rules]]
+id = "revealui-evm-wallet-address"
+description = "EVM wallet address (e.g. Coinbase x402 receiving wallet)"
+regex = '''\b0x[a-fA-F0-9]{40}\b'''
+keywords = ["0x"]
+tags = ["wallet", "boundary-config"]
+
+[[rules]]
+id = "revealui-personal-domain-email"
+description = "Personal-domain email (customer / staff PII; allowlist covers our public mailboxes)"
+regex = '''\b[A-Za-z0-9._%+-]+@(gmail|hotmail|yahoo|outlook|protonmail|icloud)\.com\b'''
+keywords = ["@gmail.com", "@hotmail.com", "@yahoo.com", "@outlook.com", "@protonmail.com", "@icloud.com"]
+tags = ["pii", "boundary-config"]
+
+# --- Client / prospect / warm-intro names ---
+#
+# Companion to scripts/check-client-leaks.sh which enforces the same names
+# on tracked repo content. Owner directive 2026-05-21: no public mention
+# anywhere outside the private revealui-jv repo. When a new client onboards,
+# extend both this rule's keywords AND the bash scanner's PATTERNS array
+# in the same PR.
+
+[[rules]]
+id = "revealui-client-allevia"
+description = "Allevia / AlleviaFleet / AlleviaForge / allevia.tech — first Tier-6 customer; internal-only per owner directive"
+regex = '''(?i)\b(allevia(?:fleet|forge)?|allevia\.tech)\b'''
+keywords = ["Allevia", "allevia", "AlleviaFleet", "AlleviaForge", "allevia.tech"]
+tags = ["client", "boundary-config"]
+
+[[rules]]
+id = "revealui-prospect-warm-intro-chain"
+description = "Stefan Wilson / Daniel B. Jones / dbjones23 — warm-intro contact chain for the first customer; surfacing publicly violates feedback_warm_intro_dont_bypass + project_allevia_contacts"
+regex = '''(Stefan Wilson|Daniel B\. Jones|dbjones23)'''
+keywords = ["Stefan Wilson", "Daniel B. Jones", "dbjones23"]
+tags = ["prospect", "boundary-config"]
+
+[[rules]]
+id = "revealui-paused-ventures"
+description = "Biotix Wellness — paused internal venture not publicly associated with this org"
+regex = '''(?i)\bbiotix(?:[ -]?wellness)?\b'''
+keywords = ["Biotix", "biotix", "Biotix Wellness", "biotix-wellness"]
+tags = ["venture", "boundary-config"]
+
+[allowlist]
+description = "Public email addresses + canonical zero/null/placeholder values"
+regexes = [
+  '''(founder|support|security|no-reply|noreply|press|hello|admin|legal|privacy)@revealui\.com''',
+  '''0x0{40}''',
+  '''(acct|prod|price|cus|sub|ch|pi|seti|in|ba|src|tok|bpc|we|mtr)_(TEST|REDACTED|PLACEHOLDER|EXAMPLE|REDACTED_[A-Za-z0-9_]+)''',
+  '''(postgres(ql)?|mysql|mongodb)://(user|USER|<user>|REDACTED):(pass|password|<password>|REDACTED)@''',
+]

--- a/.leakignore
+++ b/.leakignore
@@ -14,3 +14,10 @@ frontend/src/components/SetupScreen.test.tsx   abs-home-path
 # its grep pattern to scan for it. This is the workflow that enforces the
 # rule, not a leak of it (mirrors revkit's bare-username entry).
 .github/workflows/ci.yml                abs-wsl-windows-user
+
+# By-design: the issue/PR-body leak-scan gitleaks config (consumed by
+# .github/workflows/issue-leak-scan.yml) must name the private-path and
+# username literals in its detection regexes + keywords to catch them in
+# issue bodies. This is the config that enforces the rule, not a leak of
+# it (mirrors the ci.yml anti-regression entries).
+.gitleaks.issues.toml                   lit-username,abs-home-path,private-jv-repo,private-jv-name


### PR DESCRIPTION
Ports the issue/PR/comment body leak-scan gate from `RevealUIStudio/revealui` to this repo, byte-identical:

- `.github/workflows/issue-leak-scan.yml` — runs gitleaks against issue bodies (`opened`/`edited`), PR bodies (`pull_request_target` `opened`/`edited`), and comment bodies (`created`/`edited`). Pinned gitleaks 8.30.0 installed with SHA256 verification; bot-actor guard prevents loops on the workflow's own remediation comments.
- `.gitleaks.issues.toml` — the issue-surface rule set (extends gitleaks defaults with Stripe object-ID correlation, internal subdomains, private/internal path references, Sentry DSNs, credentialed DB connection strings, EVM wallet addresses, personal-email PII, and confidential-name rules).

On findings the workflow posts a remediation comment (rotate-before-redact guidance), applies the `contains-sensitive-content` label (created in this repo to match revealui's), and fails the run.

Why: this repo is public, so its issue/PR/comment surfaces need the same gate revealui already has. Tracked-content scanning (`scripts/check-no-private-leaks.sh` in CI) is unchanged — this closes the GitHub-conversation-surface gap only.

Note: GitHub runs `issues`/`issue_comment`-triggered workflows from the default branch, so the gate becomes fully active once this rides the next test-to-main promotion. The `pull_request_target` leg activates as soon as the file exists on the base branch.

Manual merge, no auto-merge.
