### PR TITLE
chore(deps): bump codeql-action init+analyze to 4.36.3 as a pair

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
       interval: weekly
     commit-message:
       prefix: "chore(deps)"
+    groups:
+      actions:
+        patterns: ["*"]
 
   - package-ecosystem: cargo
     directory: /

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,11 +21,11 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+      - uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: javascript-typescript
           queries: security-and-quality
           config-file: ./.github/codeql/codeql-config.yml
-      - uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+      - uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           category: /language:javascript-typescript


### PR DESCRIPTION
The CodeQL action requires `init` and `analyze` at the same version. Dependabot split the 4.36.2 → 4.36.3 bump into two PRs (#114 analyze, #115 init), so each PR's CodeQL run mixed versions and failed with `Loaded a configuration file for version '4.36.2', but running version '4.36.3'` — neither was mergeable alone (merging one would have broken CodeQL on `test`).

This bumps both refs together (SHA `54f647b` verified against the upstream `v4.36.3` tag object) and adds a dependabot `groups` stanza for the github-actions ecosystem — matching the repo's existing cargo/npm `patch-and-minor` grouping — so future action bumps arrive as a single PR. #114/#115 will auto-close once this lands.