### PR TITLE
ci(backflow): re-pin reusable workflow to signed-merge version

### DIFF
--- a/.github/workflows/backflow-main-into-test.yml
+++ b/.github/workflows/backflow-main-into-test.yml
@@ -11,5 +11,5 @@ on:
 jobs:
   backflow:
     # Pinned to immutable SHA (resolved 2026-06-12); update via gh api repos/RevealUIStudio/.github/commits/main
-    uses: RevealUIStudio/.github/.github/workflows/backflow-reusable.yml@018dbca12f2b6588b456cb2f450aadf4814729cd # main @ 2026-06-12
+    uses: RevealUIStudio/.github/.github/workflows/backflow-reusable.yml@010a9388aee91d6f6fef8fce5a18f897af42443b # main @ 2026-07-06 (backflow signed-merge — .github#7)
     secrets: inherit


### PR DESCRIPTION
Re-pins the backflow caller from `@018dbca12f2b6588b456cb2f450aadf4814729cd` to `@010a9388aee91d6f6fef8fce5a18f897af42443b` — the signed-merge version (.github#7) that creates the main→test merge via the GitHub merges API so it is GitHub-signed and passes the require-signed-commits ruleset (RS-3). Takes effect once this reaches `main` (backflow runs the caller from main). No behavior change beyond the reusable-workflow bump.